### PR TITLE
feat: Implemented map feature functions (i.e. GeoJSON support)

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,9 @@ Vue({
 * [`removeCircles(...)`](#removecircles)
 * [`addPolylines(...)`](#addpolylines)
 * [`removePolylines(...)`](#removepolylines)
+* [`addFeatures(...)`](#addfeatures)
+* [`getFeatureBounds(...)`](#getfeaturebounds)
+* [`removeFeature(...)`](#removefeature)
 * [`destroy()`](#destroy)
 * [`setCamera(...)`](#setcamera)
 * [`getMapType()`](#getmaptype)
@@ -629,6 +632,52 @@ removePolylines(ids: string[]) => Promise<void>
 | Param     | Type                  |
 | --------- | --------------------- |
 | **`ids`** | <code>string[]</code> |
+
+--------------------
+
+
+### addFeatures(...)
+
+```typescript
+addFeatures(type: FeatureType, data: any, idPropertyName?: string | undefined, styles?: FeatureStyles | undefined) => Promise<string[]>
+```
+
+| Param                | Type                                                    |
+| -------------------- | ------------------------------------------------------- |
+| **`type`**           | <code><a href="#featuretype">FeatureType</a></code>     |
+| **`data`**           | <code>any</code>                                        |
+| **`idPropertyName`** | <code>string</code>                                     |
+| **`styles`**         | <code><a href="#featurestyles">FeatureStyles</a></code> |
+
+**Returns:** <code>Promise&lt;string[]&gt;</code>
+
+--------------------
+
+
+### getFeatureBounds(...)
+
+```typescript
+getFeatureBounds(featureId: string) => Promise<LatLngBounds>
+```
+
+| Param           | Type                |
+| --------------- | ------------------- |
+| **`featureId`** | <code>string</code> |
+
+**Returns:** <code>Promise&lt;LatLngBounds&gt;</code>
+
+--------------------
+
+
+### removeFeature(...)
+
+```typescript
+removeFeature(featureId: string) => Promise<void>
+```
+
+| Param           | Type                |
+| --------------- | ------------------- |
+| **`featureId`** | <code>string</code> |
 
 --------------------
 
@@ -1158,6 +1207,11 @@ Describes the style for some region of a polyline.
 | **`segments`** | <code>number</code> | The length of this span in number of segments.                                    |
 
 
+#### FeatureStyles
+
+Feature styles, identified by the feature id
+
+
 #### CameraConfig
 
 Configuration properties for a Google Map Camera
@@ -1294,6 +1348,14 @@ Supports markers of either "legacy" or "advanced" types.
 
 
 ### Enums
+
+
+#### FeatureType
+
+| Members       | Value                  | Description |
+| ------------- | ---------------------- | ----------- |
+| **`Default`** | <code>'Default'</code> | Default     |
+| **`GeoJSON`** | <code>'GeoJSON'</code> | GeoJSON     |
 
 
 #### MapType

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -373,6 +373,9 @@ Vue({
 * [`removeCircles(...)`](#removecircles)
 * [`addPolylines(...)`](#addpolylines)
 * [`removePolylines(...)`](#removepolylines)
+* [`addFeatures(...)`](#addfeatures)
+* [`getFeatureBounds(...)`](#getfeaturebounds)
+* [`removeFeature(...)`](#removefeature)
 * [`destroy()`](#destroy)
 * [`setCamera(...)`](#setcamera)
 * [`getMapType()`](#getmaptype)
@@ -629,6 +632,52 @@ removePolylines(ids: string[]) => Promise<void>
 | Param     | Type                  |
 | --------- | --------------------- |
 | **`ids`** | <code>string[]</code> |
+
+--------------------
+
+
+### addFeatures(...)
+
+```typescript
+addFeatures(type: FeatureType, data: any, idPropertyName?: string | undefined, styles?: FeatureStyles | undefined) => Promise<string[]>
+```
+
+| Param                | Type                                                    |
+| -------------------- | ------------------------------------------------------- |
+| **`type`**           | <code><a href="#featuretype">FeatureType</a></code>     |
+| **`data`**           | <code>any</code>                                        |
+| **`idPropertyName`** | <code>string</code>                                     |
+| **`styles`**         | <code><a href="#featurestyles">FeatureStyles</a></code> |
+
+**Returns:** <code>Promise&lt;string[]&gt;</code>
+
+--------------------
+
+
+### getFeatureBounds(...)
+
+```typescript
+getFeatureBounds(featureId: string) => Promise<LatLngBounds>
+```
+
+| Param           | Type                |
+| --------------- | ------------------- |
+| **`featureId`** | <code>string</code> |
+
+**Returns:** <code>Promise&lt;LatLngBounds&gt;</code>
+
+--------------------
+
+
+### removeFeature(...)
+
+```typescript
+removeFeature(featureId: string) => Promise<void>
+```
+
+| Param           | Type                |
+| --------------- | ------------------- |
+| **`featureId`** | <code>string</code> |
 
 --------------------
 
@@ -1158,6 +1207,11 @@ Describes the style for some region of a polyline.
 | **`segments`** | <code>number</code> | The length of this span in number of segments.                                    |
 
 
+#### FeatureStyles
+
+Feature styles, identified by the feature id
+
+
 #### CameraConfig
 
 Configuration properties for a Google Map Camera
@@ -1294,6 +1348,14 @@ Supports markers of either "legacy" or "advanced" types.
 
 
 ### Enums
+
+
+#### FeatureType
+
+| Members       | Value                  | Description |
+| ------------- | ---------------------- | ----------- |
+| **`Default`** | <code>'Default'</code> | Default     |
+| **`GeoJSON`** | <code>'GeoJSON'</code> | GeoJSON     |
 
 
 #### MapType

--- a/plugin/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMap.kt
+++ b/plugin/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMap.kt
@@ -16,8 +16,19 @@ import com.google.android.gms.maps.GoogleMap.*
 import com.google.android.gms.maps.model.*
 import com.google.maps.android.clustering.Cluster
 import com.google.maps.android.clustering.ClusterManager
+import com.google.maps.android.data.Feature
+import com.google.maps.android.data.geojson.GeoJsonFeature
+import com.google.maps.android.data.geojson.GeoJsonGeometryCollection
+import com.google.maps.android.data.geojson.GeoJsonLayer
+import com.google.maps.android.data.geojson.GeoJsonLineString
+import com.google.maps.android.data.geojson.GeoJsonMultiLineString
+import com.google.maps.android.data.geojson.GeoJsonMultiPoint
+import com.google.maps.android.data.geojson.GeoJsonMultiPolygon
+import com.google.maps.android.data.geojson.GeoJsonPoint
+import com.google.maps.android.data.geojson.GeoJsonPolygon
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
+import org.json.JSONObject
 import java.io.InputStream
 import java.net.URL
 
@@ -45,7 +56,8 @@ class CapacitorGoogleMap(
     private val tileOverlays = HashMap<String, CapacitorGoogleMapTileOverlay>()
     private val polygons = HashMap<String, CapacitorGoogleMapsPolygon>()
     private val circles = HashMap<String, CapacitorGoogleMapsCircle>()
-    private val polylines = HashMap<String, CapacitorGoogleMapPolyline>()        
+    private val polylines = HashMap<String, CapacitorGoogleMapPolyline>()
+    private val featureLayers = HashMap<String, CapacitorGoogleMapsFeatureLayer>()
     private val markerIcons = HashMap<String, Bitmap>()
     private var clusterManager: ClusterManager<CapacitorGoogleMapMarker>? = null
 
@@ -412,6 +424,78 @@ class CapacitorGoogleMap(
             }
         } catch (e: GoogleMapsError) {
             callback(Result.failure(e))
+        }
+    }
+
+    fun addFeatures(type: String, data: JSONObject, idPropertyName: String?, styles: JSONObject?, callback: (ids: Result<List<String>>) -> Unit) {
+        try {
+            googleMap ?: throw GoogleMapNotAvailable()
+            val featureIds: MutableList<String> = mutableListOf()
+
+            CoroutineScope(Dispatchers.Main).launch {
+                if (type == "GeoJSON") {
+                    val tempLayer = GeoJsonLayer(null, data)
+                    tempLayer.features.forEach {
+                        try {
+                            val layer = GeoJsonLayer(googleMap, JSONObject())
+                            val featureLayer = CapacitorGoogleMapsFeatureLayer(layer, it, idPropertyName, styles)
+                            layer.addLayerToMap()
+                            if (id != null) {
+                                featureIds.add(id)
+                                featureLayers[id] = featureLayer
+                            }
+                            callback(Result.success(featureIds))
+                        } catch (e: Exception) {
+                            callback(Result.failure(e))
+                        }
+                    }
+                } else {
+                    callback(Result.failure(InvalidArgumentsError("addFeatures: not supported for this feature type")))
+                }
+            }
+        } catch (e: GoogleMapsError) {
+            callback(Result.failure(e))
+        }
+    }
+
+    fun getFeatureBounds(featureId: String, callback: (bounds: Result<LatLngBounds?>) -> Unit) {
+        try {
+            CoroutineScope(Dispatchers.Main).launch {
+                val featurelayer = featureLayers[featureId]
+                var feature: Feature? = null;
+                featurelayer?.layer?.features?.forEach lit@ {
+                    if (it.id == featurelayer.id) {
+                        feature = it
+                        return@lit
+                    }
+                }
+                if (feature != null) {
+                    try {
+                        (feature as GeoJsonFeature).let {
+                            callback(Result.success(it.boundingBoxFromGeometry()))
+                        }
+                    } catch (e: Exception) {
+                        callback(Result.failure(InvalidArgumentsError("getFeatureBounds: not supported for this feature type")))
+                    }
+                } else {
+                    callback(Result.failure(InvalidArgumentsError("Could not find feature for feature id $featureId")))
+                }
+            }
+        } catch(e: Exception) {
+            callback(Result.failure(InvalidArgumentsError("Could not find feature layer")))
+        }
+    }
+
+    fun removeFeature(featureId: String, callback: (error: GoogleMapsError?) -> Unit) {
+        CoroutineScope(Dispatchers.Main).launch {
+            val featurelayer = featureLayers[featureId]
+            if (featurelayer != null) {
+                featurelayer.layer?.removeLayerFromMap()
+                featureLayers.remove(featureId)
+                callback(null)
+            } else {
+                callback(InvalidArgumentsError("Could not find feature for feature id $featureId"))
+            }
         }
     }
 
@@ -1030,6 +1114,52 @@ class CapacitorGoogleMap(
         data.put("items", items)
 
         return data
+    }
+
+    private fun GeoJsonFeature.boundingBoxFromGeometry(): LatLngBounds? {
+        val coordinates: MutableList<LatLng> = ArrayList()
+
+        if (this.hasGeometry()) {
+            when (geometry.geometryType) {
+                "Point" -> coordinates.add((geometry as GeoJsonPoint).coordinates)
+                "MultiPoint" -> {
+                    val points = (geometry as GeoJsonMultiPoint).points
+                    for (point in points) {
+                        coordinates.add(point.coordinates)
+                    }
+                }
+
+                "LineString" -> coordinates.addAll((geometry as GeoJsonLineString).coordinates)
+                "MultiLineString" -> {
+                    val lines = (geometry as GeoJsonMultiLineString).lineStrings
+                    for (line in lines) {
+                        coordinates.addAll(line.coordinates)
+                    }
+                }
+
+                "Polygon" -> {
+                    val lists = (geometry as GeoJsonPolygon).coordinates
+                    for (list in lists) {
+                        coordinates.addAll(list)
+                    }
+                }
+
+                "MultiPolygon" -> {
+                    val polygons = (geometry as GeoJsonMultiPolygon).polygons
+                    for (polygon in polygons) {
+                        for (list in polygon.coordinates) {
+                            coordinates.addAll(list)
+                        }
+                    }
+                }
+            }
+        }
+
+        val builder = LatLngBounds.builder()
+        for (latLng in coordinates) {
+            builder.include(latLng)
+        }
+        return builder.build()
     }
 
     override fun onMapClick(point: LatLng) {

--- a/plugin/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMapsFeatureLayer.kt
+++ b/plugin/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMapsFeatureLayer.kt
@@ -1,0 +1,85 @@
+package com.capacitorjs.plugins.googlemaps
+
+import android.graphics.Color
+import com.google.maps.android.data.Feature
+import com.google.maps.android.data.Layer
+import com.google.maps.android.data.geojson.GeoJsonFeature
+import com.google.maps.android.data.geojson.GeoJsonLayer
+import org.json.JSONObject
+import java.lang.Exception
+
+class CapacitorGoogleMapsFeatureLayer(
+    layer: Layer,
+    feature: Feature,
+    idPropertyName: String?,
+    styles: JSONObject?
+) {
+    var id: String? = null
+    var layer: Layer? = null
+
+    init {
+        (feature as? GeoJsonFeature)?.let {
+            val properties: HashMap<String, String> = hashMapOf()
+            for (propertyKey in feature.propertyKeys) {
+                properties[propertyKey] = feature.getProperty(propertyKey)
+            }
+            if (idPropertyName != null) {
+                id = feature.getProperty(idPropertyName)
+            }
+            val newFeature =
+                GeoJsonFeature(
+                    feature.geometry,
+                    id,
+                    properties,
+                    null
+                )
+            this.layer = layer
+
+            val featureLayer = (layer as GeoJsonLayer)
+
+            if (styles != null) {
+                try {
+                    val styleId = id ?: feature.id
+                    val featureStyle = styleId?.let { styles.optJSONObject(it) }
+                    if (featureStyle != null) {
+                        featureLayer.defaultPolygonStyle.strokeColor =
+                            processColor(
+                                featureStyle.getString("strokeColor"),
+                                featureStyle.getDouble("strokeOpacity")
+                            )
+                        featureLayer.defaultPolygonStyle.strokeWidth =
+                            featureStyle.getDouble("strokeWeight").toFloat()
+                        featureLayer.defaultPolygonStyle.fillColor =
+                            processColor(
+                                featureStyle.getString("fillColor"),
+                                featureStyle.getDouble("fillOpacity")
+                            )
+                        featureLayer.defaultPolygonStyle.isGeodesic =
+                            featureStyle.getBoolean("geodesic")
+                        featureLayer.defaultLineStringStyle.color =
+                            featureLayer.defaultPolygonStyle.strokeColor
+                        featureLayer.defaultLineStringStyle.isGeodesic =
+                            featureLayer.defaultPolygonStyle.isGeodesic
+                    }
+                } catch (e: Exception) {
+                    throw InvalidArgumentsError("Styles object contains invalid values")
+                }
+            }
+
+            featureLayer.addFeature(newFeature)
+        }
+    }
+
+    private fun processColor(hex: String, opacity: Double): Int {
+        val colorInt = Color.parseColor(hex)
+
+        val alpha = (opacity * 255.0).toInt()
+        val red = Color.red(colorInt)
+        val green = Color.green(colorInt)
+        val blue = Color.blue(colorInt)
+
+        return Color.argb(alpha, red, green, blue)
+    }
+
+    private fun <T> JSONObject.getStyle(key: String) = this.getJSONObject(id).get(key) as T
+}

--- a/plugin/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMapsPlugin.kt
+++ b/plugin/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMapsPlugin.kt
@@ -684,6 +684,134 @@ class CapacitorGoogleMapsPlugin : Plugin(), OnMapsSdkInitializedCallback {
     }
 
     @PluginMethod
+    fun addFeatures(call: PluginCall) {
+        try {
+            val id = call.getString("id")
+            id ?: throw InvalidMapIdError()
+
+            val map = maps[id]
+            map ?: throw MapNotFoundError()
+
+            val type =
+                call.getString("type")
+                    ?: throw InvalidArgumentsError("feature type is missing")
+
+            val data =
+                call.getObject("data")
+                    ?: throw InvalidArgumentsError("feature data is missing")
+
+            val idPropertyName = call.getString("idPropertyName") ?: null
+
+            val styles = call.getObject("styles") ?: null
+
+            map.addFeatures(
+                type,
+                data,
+                idPropertyName,
+                styles
+            ) { result ->
+                try {
+                    val ids = result.getOrThrow()
+
+                    val jsonIDs = JSONArray()
+                    ids.forEach { jsonIDs.put(it) }
+
+                    val res = JSObject()
+                    res.put("ids", jsonIDs)
+                    call.resolve(res)
+                } catch (e: GoogleMapsError) {
+                    handleError(call, e)
+                } catch (e: Exception) {
+                    handleError(call, e)
+                }
+            }
+        } catch (e: GoogleMapsError) {
+            handleError(call, e)
+        } catch (e: Exception) {
+            handleError(call, e)
+        }
+    }
+
+    @PluginMethod
+    fun getFeatureBounds(call: PluginCall) {
+        try {
+            val id = call.getString("id")
+            id ?: throw InvalidMapIdError()
+
+            val map = maps[id]
+            map ?: throw MapNotFoundError()
+
+            val featureId =
+                call.getString("featureId")
+                    ?: throw InvalidArgumentsError("feature id is missing")
+
+            map.getFeatureBounds(featureId) { result ->
+                try {
+                    val featureBounds = result.getOrThrow()
+
+                    val southwest = JSObject()
+                    southwest.put("lat", featureBounds?.southwest?.latitude)
+                    southwest.put("lng", featureBounds?.southwest?.longitude)
+
+                    val center = JSObject()
+                    center.put("lat", featureBounds?.center?.latitude)
+                    center.put("lng", featureBounds?.center?.longitude)
+
+                    val northeast = JSObject()
+                    northeast.put("lat", featureBounds?.northeast?.latitude)
+                    northeast.put("lng", featureBounds?.northeast?.longitude)
+
+                    val bounds = JSObject()
+                    bounds.put("southwest", southwest)
+                    bounds.put("center", center)
+                    bounds.put("northeast", northeast)
+
+                    val res = JSObject()
+                    res.put("bounds", bounds)
+                    call.resolve(res)
+                } catch (e: GoogleMapsError) {
+                    handleError(call, e)
+                } catch (e: Exception) {
+                    handleError(call, e)
+                }
+            }
+        } catch (e: GoogleMapsError) {
+            handleError(call, e)
+        } catch (e: Exception) {
+            handleError(call, e)
+        }
+    }
+
+    @PluginMethod
+    fun removeFeature(call: PluginCall) {
+        try {
+            val id = call.getString("id")
+            id ?: throw InvalidMapIdError()
+
+            val map = maps[id]
+            map ?: throw MapNotFoundError()
+
+            val featureId =
+                call.getString("featureId")
+                    ?: throw InvalidArgumentsError("feature id is missing")
+
+            map.removeFeature(featureId) {
+                try {
+                    call.resolve()
+                } catch (e: GoogleMapsError) {
+                    handleError(call, e)
+                } catch (e: Exception) {
+                    handleError(call, e)
+                }
+            }
+        } catch (e: GoogleMapsError) {
+            handleError(call, e)
+        } catch (e: Exception) {
+            handleError(call, e)
+        }
+    }
+
+    @PluginMethod
     fun setCamera(call: PluginCall) {
         try {
             val id = call.getString("id")

--- a/plugin/ios/Sources/CapacitorGoogleMapsPlugin/Map.swift
+++ b/plugin/ios/Sources/CapacitorGoogleMapsPlugin/Map.swift
@@ -81,6 +81,7 @@ public class Map {
     var polygons = [Int: GMSPolygon]()
     var circles = [Int: GMSCircle]()
     var polylines = [Int: GMSPolyline]()
+    var features = [String: GMUGeometryRenderer]()
     var markerIcons = [String: UIImage]()
 
     // swiftlint:disable identifier_name
@@ -476,6 +477,91 @@ public class Map {
         }
     }
 
+    func addFeatures(type: String, data: JSObject, idPropertyName: String?, styles: JSObject?) throws -> [String] {
+        var featureIds: [String] = []
+
+        DispatchQueue.main.sync {
+            let jsonData : Data = try! JSONSerialization.data(withJSONObject: data, options: [])
+            let geoJSONParser = GMUGeoJSONParser(data: jsonData)
+            geoJSONParser.parse()
+
+            for container in geoJSONParser.features {
+                if let tempFeature = container as? GMUFeature, let propertes = tempFeature.properties {
+                    var featureId: String? = nil
+                    if (idPropertyName != nil) {
+                        featureId = propertes[idPropertyName!] as? String
+                    }
+                    
+                    if featureId == nil, let identifier = tempFeature.identifier {
+                        featureId = String(describing: identifier)
+                    }
+
+                    if (featureId != nil) {
+                        if let renderer = self.features[featureId!] {
+                            renderer.clear()
+                            self.features.removeValue(forKey: featureId!)
+                        }
+                    }
+
+                    let feature = GMUFeature(geometry: tempFeature.geometry, identifier: featureId, properties: tempFeature.properties, boundingBox: nil)
+
+                    if (featureId != nil) {
+                        featureIds.append(featureId!)
+                    }
+
+                    if (featureId != nil && styles != nil) {
+                        if let stylesData = (styles! as [String: Any])[featureId!] as? [String: Any] {
+                            if let strokeColor = stylesData["strokeColor"] as? String,
+                               let strokeOpacity = stylesData["strokeOpacity"] as? Double,
+                               let stroke = UIColor.init(hex: strokeColor)?.withAlphaComponent(strokeOpacity),
+                               let fillColor = stylesData["fillColor"] as? String,
+                               let fillOpacity = stylesData["fillOpacity"] as? Double,
+                               let fill = UIColor.init(hex: fillColor)?.withAlphaComponent(fillOpacity)
+                            {
+                                let style = GMUStyle(styleID: "styleId", stroke: stroke, fill: fill, width: stylesData["strokeWeight"] as? Double ?? 1, scale: 2, heading: 0, anchor: CGPoint(x: 0, y: 0), iconUrl: nil, title: nil, hasFill: true, hasStroke: true)
+                                feature.style = style
+                            }
+                        }
+                    }
+
+                    let renderer = GMUGeometryRenderer(map: self.mapViewController.GMapView, geometries: [feature])
+                    renderer.render()
+
+                    if (featureId != nil) {
+                        self.features[featureId!] = renderer
+                    }
+                }
+            }
+        }
+
+        return featureIds
+    }
+
+    func getFeatureBounds(featureId: String) throws -> GMSCoordinateBounds {
+        if let renderer = self.features[featureId] {
+            var bounds: GMSCoordinateBounds!
+
+            DispatchQueue.main.sync {
+                bounds = renderer.getBounds()
+            }
+
+            return bounds
+        } else {
+            throw GoogleMapErrors.unhandledError("feature not found")
+        }
+    }
+
+    func removeFeature(featureId: String) throws {
+        if let renderer = self.features[featureId] {
+            DispatchQueue.main.async {
+                renderer.clear()
+                self.features.removeValue(forKey: featureId)
+            }
+        } else {
+            throw GoogleMapErrors.unhandledError("feature not found")
+        }
+    }
+
     func setCamera(config: GoogleMapCameraConfig) throws {
         let currentCamera = self.mapViewController.GMapView.camera
 
@@ -803,5 +889,41 @@ extension UIImage {
         let resizedImage = UIGraphicsGetImageFromCurrentImageContext()!
         UIGraphicsEndImageContext()
         return resizedImage
+    }
+}
+
+extension GMUGeometryRenderer {
+    func getBounds() -> GMSCoordinateBounds {
+        var bounds = GMSCoordinateBounds.init()
+
+        for overlay in self.mapOverlays() {
+            if let circle = overlay as? GMSCircle {
+                bounds = bounds.includingBounds(circle.getBounds())
+            }
+            if let groundOverlay = overlay as? GMSGroundOverlay, let groundOverlayBounds = groundOverlay.bounds {
+                bounds = bounds.includingBounds(groundOverlayBounds)
+            }
+            if let marker = overlay as? GMSMarker {
+                bounds = bounds.includingCoordinate(marker.position)
+            }
+            if let polygon = overlay as? GMSPolygon, let polygonPath = polygon.path {
+                bounds = bounds.includingPath(polygonPath)
+            }
+            if let polyline = overlay as? GMSPolyline, let polylinePath = polyline.path {
+                bounds = bounds.includingPath(polylinePath)
+            }
+        }
+
+        return bounds
+    }
+}
+
+extension GMSCircle {
+    func getBounds() -> GMSCoordinateBounds {
+        var bounds = GMSCoordinateBounds.init(
+            coordinate: GMSGeometryOffset(self.position, self.radius * sqrt(2.0), 225),
+            coordinate: GMSGeometryOffset(self.position, self.radius * sqrt(2.0), 45)
+        )
+        return bounds
     }
 }

--- a/plugin/src/definitions.ts
+++ b/plugin/src/definitions.ts
@@ -131,6 +131,34 @@ export interface Polyline extends google.maps.PolylineOptions {
 }
 
 /**
+ * Feature types
+ */
+export enum FeatureType {
+  /**
+   * Default
+   */
+  Default = 'Default',
+  /**
+   * GeoJSON
+   */
+  GeoJSON = 'GeoJSON',
+}
+
+/**
+ * Feature styles, identified by the feature id
+ */
+export interface FeatureStyles {
+  [key: string]: {
+    strokeColor: string;
+    strokeOpacity: number;
+    strokeWeight: number;
+    fillColor: string;
+    fillOpacity: number;
+    geodesic: boolean;
+  };
+}
+
+/**
  * Describes the style for some region of a polyline.
  */
 export interface StyleSpan {

--- a/plugin/src/implementation.ts
+++ b/plugin/src/implementation.ts
@@ -13,6 +13,8 @@ import type {
   Polygon,
   Polyline,
   TileOverlay,
+  FeatureType,
+  FeatureStyles,
 } from './definitions';
 
 /**
@@ -93,6 +95,7 @@ export interface RemoveCirclesArgs {
   id: string;
   circleIds: string[];
 }
+
 export interface AddPolylinesArgs {
   id: string;
   polylines: Polyline[];
@@ -101,6 +104,24 @@ export interface AddPolylinesArgs {
 export interface RemovePolylinesArgs {
   id: string;
   polylineIds: string[];
+}
+
+export interface AddFeatureArgs {
+  id: string;
+  type: FeatureType;
+  data: any;
+  idPropertyName?: string;
+  styles?: FeatureStyles;
+}
+
+export interface GetFeatureBoundsArgs {
+  id: string;
+  featureId: string;
+}
+
+export interface RemoveFeatureArgs {
+  id: string;
+  featureId: string;
 }
 
 export interface CameraArgs {
@@ -195,6 +216,9 @@ export interface CapacitorGoogleMapsPlugin extends Plugin {
   addCircles(args: AddCirclesArgs): Promise<{ ids: string[] }>;
   removeCircles(args: RemoveCirclesArgs): Promise<void>;
   addPolylines(args: AddPolylinesArgs): Promise<{ ids: string[] }>;
+  addFeatures(args: AddFeatureArgs): Promise<{ ids: string[] }>;
+  getFeatureBounds(args: GetFeatureBoundsArgs): Promise<{ bounds: LatLngBounds }>;
+  removeFeature(args: RemoveFeatureArgs): Promise<void>;
   removePolylines(args: RemovePolylinesArgs): Promise<void>;
   enableClustering(args: EnableClusteringArgs): Promise<void>;
   disableClustering(args: { id: string }): Promise<void>;

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -1,8 +1,18 @@
 /* eslint-disable @typescript-eslint/no-namespace */
-import { LatLngBounds, MapType, Marker, Polygon, Circle, Polyline, StyleSpan } from './definitions';
+import {
+  LatLngBounds,
+  MapType,
+  Marker,
+  Polygon,
+  Circle,
+  Polyline,
+  StyleSpan,
+  FeatureType,
+  FeatureStyles,
+} from './definitions';
 import { GoogleMap } from './map';
 
-export { GoogleMap, LatLngBounds, MapType, Marker, Polygon, Circle, Polyline, StyleSpan };
+export { GoogleMap, LatLngBounds, MapType, Marker, Polygon, Circle, Polyline, StyleSpan, FeatureType, FeatureStyles };
 
 declare global {
   export namespace JSX {

--- a/plugin/src/map.ts
+++ b/plugin/src/map.ts
@@ -20,6 +20,8 @@ import type {
   Polyline,
   PolylineCallbackData,
   TileOverlay,
+  FeatureType,
+  FeatureStyles,
 } from './definitions';
 import { LatLngBounds, MapType } from './definitions';
 import type { CreateMapArgs } from './implementation';
@@ -48,6 +50,9 @@ export interface GoogleMapInterface {
   removeCircles(ids: string[]): Promise<void>;
   addPolylines(polylines: Polyline[]): Promise<string[]>;
   removePolylines(ids: string[]): Promise<void>;
+  addFeatures(type: FeatureType, data: any, idPropertyName?: string, styles?: FeatureStyles): Promise<string[]>;
+  getFeatureBounds(featureId: string): Promise<LatLngBounds>;
+  removeFeature(featureId: string): Promise<void>;
   destroy(): Promise<void>;
   setCamera(config: CameraConfig): Promise<void>;
   /**
@@ -465,6 +470,34 @@ export class GoogleMap {
     return CapacitorGoogleMaps.removePolylines({
       id: this.id,
       polylineIds: ids,
+    });
+  }
+
+  async addFeatures(type: FeatureType, data: any, idPropertyName?: string, styles?: FeatureStyles): Promise<string[]> {
+    const res = await CapacitorGoogleMaps.addFeatures({
+      id: this.id,
+      type,
+      data,
+      idPropertyName,
+      styles,
+    });
+
+    return res.ids;
+  }
+
+  async getFeatureBounds(id: string): Promise<LatLngBounds> {
+    const res = await CapacitorGoogleMaps.getFeatureBounds({
+      id: this.id,
+      featureId: id,
+    });
+
+    return new LatLngBounds(res.bounds);
+  }
+
+  async removeFeature(id: string): Promise<void> {
+    return CapacitorGoogleMaps.removeFeature({
+      id: this.id,
+      featureId: id,
     });
   }
 

--- a/plugin/src/web.ts
+++ b/plugin/src/web.ts
@@ -2,8 +2,8 @@ import { WebPlugin } from '@capacitor/core';
 import type { Cluster, onClusterClickHandler } from '@googlemaps/markerclusterer';
 import { MarkerClusterer, SuperClusterAlgorithm } from '@googlemaps/markerclusterer';
 
-import type { Marker, TileOverlay } from './definitions';
-import { MapType, LatLngBounds } from './definitions';
+import type { LatLngBoundsInterface, LatLng, Marker, TileOverlay } from './definitions';
+import { FeatureType, MapType, LatLngBounds } from './definitions';
 import type {
   AddTileOverlayArgs,
   AddMarkerArgs,
@@ -29,6 +29,9 @@ import type {
   AddPolylinesArgs,
   RemovePolylinesArgs,
   RemoveTileOverlayArgs,
+  AddFeatureArgs,
+  GetFeatureBoundsArgs,
+  RemoveFeatureArgs,
 } from './implementation';
 
 export class CapacitorGoogleMapsWeb extends WebPlugin implements CapacitorGoogleMapsPlugin {
@@ -438,6 +441,79 @@ export class CapacitorGoogleMapsWeb extends WebPlugin implements CapacitorGoogle
       map.polylines[id].setMap(null);
       delete map.polylines[id];
     }
+  }
+
+  async addFeatures(args: AddFeatureArgs): Promise<{ ids: string[] }> {
+    const featureIds: string[] = [];
+    const map = this.maps[args.id];
+
+    if (args.type === FeatureType.GeoJSON) {
+      featureIds.push(
+        ...(map.map.data
+          .addGeoJson(args.data, args.idPropertyName ? { idPropertyName: args.idPropertyName } : null)
+          .map((f) => f.getId())
+          .filter((f) => f !== undefined)
+          .map((f) => f?.toString()) as string[]),
+      );
+    } else {
+      const featureId = map.map.data.add(args.data).getId();
+      if (featureId) {
+        featureIds.push(featureId.toString());
+      }
+    }
+
+    if (args.styles) {
+      map.map.data.setStyle((feature) => {
+        const featureId = feature.getId();
+        return featureId ? (args.styles?.[featureId] as any) : null;
+      });
+    }
+
+    return {
+      ids: featureIds,
+    };
+  }
+
+  async getFeatureBounds(args: GetFeatureBoundsArgs): Promise<{ bounds: LatLngBounds }> {
+    if (!args.featureId) {
+      throw new Error('Feature id not set.');
+    }
+
+    const map = this.maps[args.id];
+    const feature = map.map.data.getFeatureById(args.featureId);
+
+    if (!feature) {
+      throw new Error(`Feature '${args.featureId}' could not be found.`);
+    }
+
+    const bounds = new google.maps.LatLngBounds();
+
+    feature?.getGeometry()?.forEachLatLng((latLng) => {
+      bounds.extend(latLng);
+    });
+
+    return {
+      bounds: new LatLngBounds({
+        southwest: bounds.getSouthWest().toJSON() as LatLng,
+        center: bounds.getCenter().toJSON() as LatLng,
+        northeast: bounds.getNorthEast().toJSON() as LatLng,
+      } as LatLngBoundsInterface),
+    };
+  }
+
+  async removeFeature(args: RemoveFeatureArgs): Promise<void> {
+    if (!args.featureId) {
+      throw new Error('Feature id not set.');
+    }
+
+    const map = this.maps[args.id];
+
+    const feature = map.map.data.getFeatureById(args.featureId);
+    if (!feature) {
+      throw new Error(`Feature '${args.featureId}' could not be found.`);
+    }
+
+    map.map.data.remove(feature);
   }
 
   async enableClustering(_args: EnableClusteringArgs): Promise<void> {


### PR DESCRIPTION
This PR adds support (first implementation scoped to geoJson) for map features.

### Examples 
#### addFeatures(type: FeatureType, data: any, idPropertyName: string, styles: FeatureStyles): string[]
```
await map.addFeatures(
    FeatureType.GeoJSON,
    {
        type: 'Feature',
        geometry: GeoJSONData,
        properties: {
            id: 'my-identifier',
        },
    },
    'id',
    {
        ['my-identifier']: {
            strokeColor: '#123456',
            strokeOpacity: 0.8,
            strokeWeight: 1,
            fillColor: '#654321',
            fillOpacity: 0.1,
            geodesic: true,
        }
    }
)
```

#### getFeatureBounds(featureId: string)
`map.getFeatureBounds('my-identifier')`

#### removeFeature(featureId: string)
`map.removeFeature('my-identifier')`

Closes https://github.com/ionic-team/capacitor-google-maps/issues/20