### PR TITLE
feat(google-maps): Refactored options and added feature to update the map options

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,8 @@ Vue({
 <docgen-index>
 
 * [`create(...)`](#create)
+* [`update(...)`](#update)
+* [`getOptions()`](#getoptions)
 * [`enableTouch()`](#enabletouch)
 * [`disableTouch()`](#disabletouch)
 * [`enableClustering(...)`](#enableclustering)
@@ -421,6 +423,30 @@ create(options: CreateMapArgs, callback?: MapListenerCallback<MapReadyCallbackDa
 | **`callback`** | <code><a href="#maplistenercallback">MapListenerCallback</a>&lt;<a href="#mapreadycallbackdata">MapReadyCallbackData</a>&gt;</code> |
 
 **Returns:** <code>Promise&lt;GoogleMap&gt;</code>
+
+--------------------
+
+
+### update(...)
+
+```typescript
+update(config: GoogleMapConfig) => Promise<void>
+```
+
+| Param        | Type                                                        |
+| ------------ | ----------------------------------------------------------- |
+| **`config`** | <code><a href="#googlemapconfig">GoogleMapConfig</a></code> |
+
+--------------------
+
+
+### getOptions()
+
+```typescript
+getOptions() => GoogleMapConfig | null
+```
+
+**Returns:** <code><a href="#googlemapconfig">GoogleMapConfig</a> | null</code>
 
 --------------------
 
@@ -990,42 +1016,44 @@ setOnMyLocationClickListener(callback?: MapListenerCallback<MapClickCallbackData
 
 An interface containing the options used when creating a map.
 
-| Prop              | Type                                                        | Description                                                                                                                                                                            | Default            |
-| ----------------- | ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
-| **`id`**          | <code>string</code>                                         | A unique identifier for the map instance.                                                                                                                                              |                    |
-| **`apiKey`**      | <code>string</code>                                         | The Google Maps SDK API Key.                                                                                                                                                           |                    |
-| **`config`**      | <code><a href="#googlemapconfig">GoogleMapConfig</a></code> | The initial configuration settings for the map.                                                                                                                                        |                    |
-| **`element`**     | <code>HTMLElement</code>                                    | The DOM element that the Google Map View will be mounted on which determines size and positioning.                                                                                     |                    |
-| **`forceCreate`** | <code>boolean</code>                                        | Destroy and re-create the map instance if a map with the supplied id already exists                                                                                                    | <code>false</code> |
-| **`region`**      | <code>string</code>                                         | The region parameter alters your application to serve different map tiles or bias the application (such as biasing geocoding results towards the region). Only available for web.      |                    |
-| **`language`**    | <code>string</code>                                         | The language parameter affects the names of controls, copyright notices, driving directions, and control labels, as well as the responses to service requests. Only available for web. |                    |
+| Prop              | Type                                                                    | Description                                                                                                                                                                            | Default            |
+| ----------------- | ----------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
+| **`id`**          | <code>string</code>                                                     | A unique identifier for the map instance.                                                                                                                                              |                    |
+| **`apiKey`**      | <code>string</code>                                                     | The Google Maps SDK API Key.                                                                                                                                                           |                    |
+| **`config`**      | <code><a href="#googlemapcreateconfig">GoogleMapCreateConfig</a></code> | The initial configuration settings for the map.                                                                                                                                        |                    |
+| **`element`**     | <code>HTMLElement</code>                                                | The DOM element that the Google Map View will be mounted on which determines size and positioning.                                                                                     |                    |
+| **`forceCreate`** | <code>boolean</code>                                                    | Destroy and re-create the map instance if a map with the supplied id already exists                                                                                                    | <code>false</code> |
+| **`region`**      | <code>string</code>                                                     | The region parameter alters your application to serve different map tiles or bias the application (such as biasing geocoding results towards the region). Only available for web.      |                    |
+| **`language`**    | <code>string</code>                                                     | The language parameter affects the names of controls, copyright notices, driving directions, and control labels, as well as the responses to service requests. Only available for web. |                    |
 
 
-#### GoogleMapConfig
+#### GoogleMapCreateConfig
 
 For web, all the javascript Google Maps options are available as
-GoogleMapConfig extends google.maps.MapOptions.
-For iOS and Android only the config options declared on <a href="#googlemapconfig">GoogleMapConfig</a> are available.
+GoogleMapCreateConfig extends google.maps.MapOptions.
+For iOS and Android the following options from google.maps.MapOptions with the same signature are additionally available:
+- gestureHandling ('none' | 'auto')
+- heading
+- mapTypeId
+- maxZoom
+- minZoom
+- restriction
+- styles
+- zoom
 
-| Prop                   | Type                                      | Description                                                                                                                                                                                                                                                                                                                                               | Default            | Since |
-| ---------------------- | ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ----- |
-| **`width`**            | <code>number</code>                       | Override width for native map.                                                                                                                                                                                                                                                                                                                            |                    |       |
-| **`height`**           | <code>number</code>                       | Override height for native map.                                                                                                                                                                                                                                                                                                                           |                    |       |
-| **`x`**                | <code>number</code>                       | Override absolute x coordinate position for native map.                                                                                                                                                                                                                                                                                                   |                    |       |
-| **`y`**                | <code>number</code>                       | Override absolute y coordinate position for native map.                                                                                                                                                                                                                                                                                                   |                    |       |
-| **`center`**           | <code><a href="#latlng">LatLng</a></code> | Default location on the Earth towards which the camera points.                                                                                                                                                                                                                                                                                            |                    |       |
-| **`zoom`**             | <code>number</code>                       | Sets the zoom of the map.                                                                                                                                                                                                                                                                                                                                 |                    |       |
-| **`androidLiteMode`**  | <code>boolean</code>                      | Enables image-based lite mode on Android.                                                                                                                                                                                                                                                                                                                 | <code>false</code> |       |
-| **`devicePixelRatio`** | <code>number</code>                       | Override pixel ratio for native map.                                                                                                                                                                                                                                                                                                                      |                    |       |
-| **`styles`**           | <code>MapTypeStyle[] \| null</code>       | Styles to apply to each of the default map types. Note that for satellite, hybrid and terrain modes, these styles will only apply to labels and geometry.                                                                                                                                                                                                 |                    | 4.3.0 |
-| **`mapId`**            | <code>string</code>                       | A map id associated with a specific map style or feature. [Use Map IDs](https://developers.google.com/maps/documentation/get-map-id) Only for Web.                                                                                                                                                                                                        |                    | 5.4.0 |
-| **`androidMapId`**     | <code>string</code>                       | A map id associated with a specific map style or feature. [Use Map IDs](https://developers.google.com/maps/documentation/get-map-id) Only for Android.                                                                                                                                                                                                    |                    | 5.4.0 |
-| **`iOSMapId`**         | <code>string</code>                       | A map id associated with a specific map style or feature. [Use Map IDs](https://developers.google.com/maps/documentation/get-map-id) Only for iOS.                                                                                                                                                                                                        |                    | 5.4.0 |
-| **`maxZoom`**          | <code>number \| null</code>               | The maximum zoom level which will be displayed on the map. If omitted, or set to &lt;code&gt;null&lt;/code&gt;, the maximum zoom from the current map type is used instead. Valid zoom values are numbers from zero up to the supported &lt;a href="https://developers.google.com/maps/documentation/javascript/maxzoom"&gt;maximum zoom level&lt;/a&gt;. |                    |       |
-| **`minZoom`**          | <code>number \| null</code>               | The minimum zoom level which will be displayed on the map. If omitted, or set to &lt;code&gt;null&lt;/code&gt;, the minimum zoom from the current map type is used instead. Valid zoom values are numbers from zero up to the supported &lt;a href="https://developers.google.com/maps/documentation/javascript/maxzoom"&gt;maximum zoom level&lt;/a&gt;. |                    |       |
-| **`mapTypeId`**        | <code>string \| null</code>               | The initial Map mapTypeId. Defaults to &lt;code&gt;ROADMAP&lt;/code&gt;.                                                                                                                                                                                                                                                                                  |                    |       |
-| **`heading`**          | <code>number \| null</code>               | The heading for aerial imagery in degrees measured clockwise from cardinal direction North. Headings are snapped to the nearest available angle for which imagery is available.                                                                                                                                                                           |                    |       |
-| **`restriction`**      | <code>MapRestriction \| null</code>       | Defines a boundary that restricts the area of the map accessible to users. When set, a user can only pan and zoom while the camera view stays inside the limits of the boundary.                                                                                                                                                                          |                    |       |
+| Prop                   | Type                                      | Description                                                                                                                                            | Default            | Since |
+| ---------------------- | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------ | ----- |
+| **`width`**            | <code>number</code>                       | Override width for native map.                                                                                                                         |                    |       |
+| **`height`**           | <code>number</code>                       | Override height for native map.                                                                                                                        |                    |       |
+| **`x`**                | <code>number</code>                       | Override absolute x coordinate position for native map.                                                                                                |                    |       |
+| **`y`**                | <code>number</code>                       | Override absolute y coordinate position for native map.                                                                                                |                    |       |
+| **`center`**           | <code><a href="#latlng">LatLng</a></code> | Default location on the Earth towards which the camera points.                                                                                         |                    |       |
+| **`zoom`**             | <code>number</code>                       | Sets the zoom of the map.                                                                                                                              |                    |       |
+| **`androidLiteMode`**  | <code>boolean</code>                      | Enables image-based lite mode on Android.                                                                                                              | <code>false</code> |       |
+| **`devicePixelRatio`** | <code>number</code>                       | Override pixel ratio for native map.                                                                                                                   |                    |       |
+| **`mapId`**            | <code>string</code>                       | A map id associated with a specific map style or feature. [Use Map IDs](https://developers.google.com/maps/documentation/get-map-id) Only for Web.     |                    | 5.4.0 |
+| **`androidMapId`**     | <code>string</code>                       | A map id associated with a specific map style or feature. [Use Map IDs](https://developers.google.com/maps/documentation/get-map-id) Only for Android. |                    | 5.4.0 |
+| **`iOSMapId`**         | <code>string</code>                       | A map id associated with a specific map style or feature. [Use Map IDs](https://developers.google.com/maps/documentation/get-map-id) Only for iOS.     |                    | 5.4.0 |
 
 
 #### LatLng
@@ -1043,6 +1071,46 @@ An interface representing a pair of latitude and longitude coordinates.
 | Prop        | Type                |
 | ----------- | ------------------- |
 | **`mapId`** | <code>string</code> |
+
+
+#### GoogleMapConfig
+
+For web, all the javascript Google Maps options are available as
+GoogleMapConfig extends google.maps.MapOptions.
+For iOS and Android the following options from google.maps.MapOptions with the same signature are additionally available:
+- gestureHandling ('none' | 'auto')
+- heading
+- mapTypeId
+- maxZoom
+- minZoom
+- restriction
+- styles
+
+| Prop                                 | Type                                              | Description                                                                                                                                        |
+| ------------------------------------ | ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`isAccessibilityElementsEnabled`** | <code>boolean</code>                              | Show accessibility elements for overlay objects, such as <a href="#marker">Marker</a> and <a href="#polyline">Polyline</a>. Only available on iOS. |
+| **`isCompassEnabled`**               | <code>boolean</code>                              | Enables or disables the compass.                                                                                                                   |
+| **`isMyLocationButtonEnabled`**      | <code>boolean</code>                              | Sets whether a button should be displayed, which centers the camera to the users current position.                                                 |
+| **`isMyLocationEnabled`**            | <code>boolean</code>                              | Sets whether the My Location dot and accuracy circle is enabled.                                                                                   |
+| **`isIndoorMapsEnabled`**            | <code>boolean</code>                              | Sets whether indoor maps should be enabled. Only available on Android and iOS.                                                                     |
+| **`isRotateGesturesEnabled`**        | <code>boolean</code>                              | Sets the preference for whether rotate gestures should be enabled or disabled.                                                                     |
+| **`isTiltGesturesEnabled`**          | <code>boolean</code>                              | Sets the preference for whether tilt gestures should be enabled or disabled.                                                                       |
+| **`isToolbarEnabled`**               | <code>boolean</code>                              | Sets the preference for whether the Map Toolbar should be enabled or disabled. Only available on Android.                                          |
+| **`isTrafficLayerEnabled`**          | <code>boolean</code>                              | Turns the traffic layer on or off.                                                                                                                 |
+| **`isZoomGesturesEnabled`**          | <code>boolean</code>                              | Sets the preference for whether zoom gestures should be enabled or disabled.                                                                       |
+| **`padding`**                        | <code><a href="#mappadding">MapPadding</a></code> | Padding on the 'visible' region of the view.                                                                                                       |
+
+
+#### MapPadding
+
+Controls for setting padding on the 'visible' region of the view.
+
+| Prop         | Type                |
+| ------------ | ------------------- |
+| **`top`**    | <code>number</code> |
+| **`left`**   | <code>number</code> |
+| **`right`**  | <code>number</code> |
+| **`bottom`** | <code>number</code> |
 
 
 #### TileOverlay
@@ -1170,18 +1238,6 @@ Configuration properties for a Google Map Camera
 | **`angle`**             | <code>number</code>                       | The angle, in degrees, of the camera from the nadir (directly facing the Earth). The only allowed values are 0 and 45. | <code>0</code>     |
 | **`animate`**           | <code>boolean</code>                      | Animate the transition to the new Camera properties.                                                                   | <code>false</code> |
 | **`animationDuration`** | <code>number</code>                       | This configuration option is not being used.                                                                           |                    |
-
-
-#### MapPadding
-
-Controls for setting padding on the 'visible' region of the view.
-
-| Prop         | Type                |
-| ------------ | ------------------- |
-| **`top`**    | <code>number</code> |
-| **`left`**   | <code>number</code> |
-| **`right`**  | <code>number</code> |
-| **`bottom`** | <code>number</code> |
 
 
 #### CameraIdleCallbackData

--- a/example-app/src/pages/Map/ConfigMap.tsx
+++ b/example-app/src/pages/Map/ConfigMap.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import { GoogleMap } from '@capacitor/google-maps';
-import { MapType } from '@capacitor/google-maps';
 import { IonButton, IonTextarea } from '@ionic/react';
 import BaseTestingPage from '../../components/BaseTestingPage';
 
@@ -87,10 +86,10 @@ const ConfigMapPage: React.FC = () => {
         setCommandOutput("");
         try {
             const map1 = maps[0];
-            await map1.setMapType(MapType.Terrain)
+            await map1.update({ mapTypeId: 'terrain' })
 
             const map2 = maps[1];
-            await map2.setMapType(MapType.Satellite)
+            await map2.update({ mapTypeId: 'satellite' })
         } catch(err: any) {
             setCommandOutput(err.message);
         }
@@ -111,7 +110,7 @@ const ConfigMapPage: React.FC = () => {
                 animate: true,
                 animationDuration: 50,
             })
-            await map1.enableIndoorMaps(true);
+            await map1.update({ isIndoorMapsEnabled: true });
         } catch(err: any) {
             setCommandOutput(err.message);
         }
@@ -121,7 +120,7 @@ const ConfigMapPage: React.FC = () => {
         setCommandOutput("");
         try {
             const map1 = maps[0];           
-            await map1.enableTrafficLayer(true);
+            await map1.update({ isTrafficLayerEnabled: true });
             await map1.setCamera({               
                 zoom: 10,
                 animate: true,
@@ -129,7 +128,7 @@ const ConfigMapPage: React.FC = () => {
             })
 
             const map2 = maps[0];           
-            await map2.enableTrafficLayer(true);
+            await map2.update({ isTrafficLayerEnabled: true });
         } catch(err: any) {
             setCommandOutput(err.message);
         }
@@ -139,10 +138,10 @@ const ConfigMapPage: React.FC = () => {
         setCommandOutput("");
         try {
             const map1 = maps[0];           
-            await map1.enableTrafficLayer(false);
+            await map1.update({ isTrafficLayerEnabled: false });
 
             const map2 = maps[0];           
-            await map2.enableTrafficLayer(false);
+            await map2.update({ isTrafficLayerEnabled: false });
         } catch(err: any) {
             setCommandOutput(err.message);
         }
@@ -171,7 +170,7 @@ const ConfigMapPage: React.FC = () => {
                 animate: true,
                 animationDuration: 50,
             })
-            await map1.enableCurrentLocation(true);
+            await map1.update({ isMyLocationEnabled: true });
 
             const map2 = maps[1];                       
             await map2.setCamera({               
@@ -179,7 +178,7 @@ const ConfigMapPage: React.FC = () => {
                 animate: true,
                 animationDuration: 50,
             });
-            await map2.enableCurrentLocation(true);
+            await map2.update({ isMyLocationEnabled: true });
         } catch(err: any) {
             setCommandOutput(err.message);
         }
@@ -189,10 +188,10 @@ const ConfigMapPage: React.FC = () => {
         setCommandOutput("");
         try {
             const map1 = maps[0];                                   
-            await map1.enableCurrentLocation(false);
+            await map1.update({ isMyLocationEnabled: false });
 
             const map2 = maps[1];                                 
-            await map2.enableCurrentLocation(false);
+            await map2.update({ isMyLocationEnabled: false });
         } catch(err: any) {
             setCommandOutput(err.message);
         }
@@ -202,10 +201,10 @@ const ConfigMapPage: React.FC = () => {
         setCommandOutput("");
         try {
             const map1 = maps[0];                                   
-            await map1.enableAccessibilityElements(true);
+            await map1.update({ isAccessibilityElementsEnabled: true });
 
             const map2 = maps[1];                                 
-            await map2.enableAccessibilityElements(true);
+            await map2.update({ isAccessibilityElementsEnabled: true });
         } catch(err: any) {
             setCommandOutput(err.message);
         }
@@ -215,10 +214,10 @@ const ConfigMapPage: React.FC = () => {
         setCommandOutput("");
         try {
             const map1 = maps[0];                                   
-            await map1.enableAccessibilityElements(false);
+            await map1.update({ isAccessibilityElementsEnabled: false });
 
             const map2 = maps[1];                                 
-            await map2.enableAccessibilityElements(false);
+            await map2.update({ isAccessibilityElementsEnabled: false });
         } catch(err: any) {
             setCommandOutput(err.message);
         }

--- a/example-app/src/pages/Markers/MultipleMarkers.tsx
+++ b/example-app/src/pages/Markers/MultipleMarkers.tsx
@@ -210,7 +210,7 @@ const MultipleMarkers: React.FC = () => {
       animate: true,
       animationDuration: 50,
     });
-    await map?.enableCurrentLocation(true);
+    await map?.update({ isMyLocationEnabled: true });
   }
 
   async function showCurrentBounds() {

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -357,6 +357,8 @@ Vue({
 <docgen-index>
 
 * [`create(...)`](#create)
+* [`update(...)`](#update)
+* [`getOptions()`](#getoptions)
 * [`enableTouch()`](#enabletouch)
 * [`disableTouch()`](#disabletouch)
 * [`enableClustering(...)`](#enableclustering)
@@ -421,6 +423,30 @@ create(options: CreateMapArgs, callback?: MapListenerCallback<MapReadyCallbackDa
 | **`callback`** | <code><a href="#maplistenercallback">MapListenerCallback</a>&lt;<a href="#mapreadycallbackdata">MapReadyCallbackData</a>&gt;</code> |
 
 **Returns:** <code>Promise&lt;GoogleMap&gt;</code>
+
+--------------------
+
+
+### update(...)
+
+```typescript
+update(config: GoogleMapConfig) => Promise<void>
+```
+
+| Param        | Type                                                        |
+| ------------ | ----------------------------------------------------------- |
+| **`config`** | <code><a href="#googlemapconfig">GoogleMapConfig</a></code> |
+
+--------------------
+
+
+### getOptions()
+
+```typescript
+getOptions() => GoogleMapConfig | null
+```
+
+**Returns:** <code><a href="#googlemapconfig">GoogleMapConfig</a> | null</code>
 
 --------------------
 
@@ -990,42 +1016,44 @@ setOnMyLocationClickListener(callback?: MapListenerCallback<MapClickCallbackData
 
 An interface containing the options used when creating a map.
 
-| Prop              | Type                                                        | Description                                                                                                                                                                            | Default            |
-| ----------------- | ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
-| **`id`**          | <code>string</code>                                         | A unique identifier for the map instance.                                                                                                                                              |                    |
-| **`apiKey`**      | <code>string</code>                                         | The Google Maps SDK API Key.                                                                                                                                                           |                    |
-| **`config`**      | <code><a href="#googlemapconfig">GoogleMapConfig</a></code> | The initial configuration settings for the map.                                                                                                                                        |                    |
-| **`element`**     | <code>HTMLElement</code>                                    | The DOM element that the Google Map View will be mounted on which determines size and positioning.                                                                                     |                    |
-| **`forceCreate`** | <code>boolean</code>                                        | Destroy and re-create the map instance if a map with the supplied id already exists                                                                                                    | <code>false</code> |
-| **`region`**      | <code>string</code>                                         | The region parameter alters your application to serve different map tiles or bias the application (such as biasing geocoding results towards the region). Only available for web.      |                    |
-| **`language`**    | <code>string</code>                                         | The language parameter affects the names of controls, copyright notices, driving directions, and control labels, as well as the responses to service requests. Only available for web. |                    |
+| Prop              | Type                                                                    | Description                                                                                                                                                                            | Default            |
+| ----------------- | ----------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
+| **`id`**          | <code>string</code>                                                     | A unique identifier for the map instance.                                                                                                                                              |                    |
+| **`apiKey`**      | <code>string</code>                                                     | The Google Maps SDK API Key.                                                                                                                                                           |                    |
+| **`config`**      | <code><a href="#googlemapcreateconfig">GoogleMapCreateConfig</a></code> | The initial configuration settings for the map.                                                                                                                                        |                    |
+| **`element`**     | <code>HTMLElement</code>                                                | The DOM element that the Google Map View will be mounted on which determines size and positioning.                                                                                     |                    |
+| **`forceCreate`** | <code>boolean</code>                                                    | Destroy and re-create the map instance if a map with the supplied id already exists                                                                                                    | <code>false</code> |
+| **`region`**      | <code>string</code>                                                     | The region parameter alters your application to serve different map tiles or bias the application (such as biasing geocoding results towards the region). Only available for web.      |                    |
+| **`language`**    | <code>string</code>                                                     | The language parameter affects the names of controls, copyright notices, driving directions, and control labels, as well as the responses to service requests. Only available for web. |                    |
 
 
-#### GoogleMapConfig
+#### GoogleMapCreateConfig
 
 For web, all the javascript Google Maps options are available as
-GoogleMapConfig extends google.maps.MapOptions.
-For iOS and Android only the config options declared on <a href="#googlemapconfig">GoogleMapConfig</a> are available.
+GoogleMapCreateConfig extends google.maps.MapOptions.
+For iOS and Android the following options from google.maps.MapOptions with the same signature are additionally available:
+- gestureHandling ('none' | 'auto')
+- heading
+- mapTypeId
+- maxZoom
+- minZoom
+- restriction
+- styles
+- zoom
 
-| Prop                   | Type                                      | Description                                                                                                                                                                                                                                                                                                                                               | Default            | Since |
-| ---------------------- | ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ----- |
-| **`width`**            | <code>number</code>                       | Override width for native map.                                                                                                                                                                                                                                                                                                                            |                    |       |
-| **`height`**           | <code>number</code>                       | Override height for native map.                                                                                                                                                                                                                                                                                                                           |                    |       |
-| **`x`**                | <code>number</code>                       | Override absolute x coordinate position for native map.                                                                                                                                                                                                                                                                                                   |                    |       |
-| **`y`**                | <code>number</code>                       | Override absolute y coordinate position for native map.                                                                                                                                                                                                                                                                                                   |                    |       |
-| **`center`**           | <code><a href="#latlng">LatLng</a></code> | Default location on the Earth towards which the camera points.                                                                                                                                                                                                                                                                                            |                    |       |
-| **`zoom`**             | <code>number</code>                       | Sets the zoom of the map.                                                                                                                                                                                                                                                                                                                                 |                    |       |
-| **`androidLiteMode`**  | <code>boolean</code>                      | Enables image-based lite mode on Android.                                                                                                                                                                                                                                                                                                                 | <code>false</code> |       |
-| **`devicePixelRatio`** | <code>number</code>                       | Override pixel ratio for native map.                                                                                                                                                                                                                                                                                                                      |                    |       |
-| **`styles`**           | <code>MapTypeStyle[] \| null</code>       | Styles to apply to each of the default map types. Note that for satellite, hybrid and terrain modes, these styles will only apply to labels and geometry.                                                                                                                                                                                                 |                    | 4.3.0 |
-| **`mapId`**            | <code>string</code>                       | A map id associated with a specific map style or feature. [Use Map IDs](https://developers.google.com/maps/documentation/get-map-id) Only for Web.                                                                                                                                                                                                        |                    | 5.4.0 |
-| **`androidMapId`**     | <code>string</code>                       | A map id associated with a specific map style or feature. [Use Map IDs](https://developers.google.com/maps/documentation/get-map-id) Only for Android.                                                                                                                                                                                                    |                    | 5.4.0 |
-| **`iOSMapId`**         | <code>string</code>                       | A map id associated with a specific map style or feature. [Use Map IDs](https://developers.google.com/maps/documentation/get-map-id) Only for iOS.                                                                                                                                                                                                        |                    | 5.4.0 |
-| **`maxZoom`**          | <code>number \| null</code>               | The maximum zoom level which will be displayed on the map. If omitted, or set to &lt;code&gt;null&lt;/code&gt;, the maximum zoom from the current map type is used instead. Valid zoom values are numbers from zero up to the supported &lt;a href="https://developers.google.com/maps/documentation/javascript/maxzoom"&gt;maximum zoom level&lt;/a&gt;. |                    |       |
-| **`minZoom`**          | <code>number \| null</code>               | The minimum zoom level which will be displayed on the map. If omitted, or set to &lt;code&gt;null&lt;/code&gt;, the minimum zoom from the current map type is used instead. Valid zoom values are numbers from zero up to the supported &lt;a href="https://developers.google.com/maps/documentation/javascript/maxzoom"&gt;maximum zoom level&lt;/a&gt;. |                    |       |
-| **`mapTypeId`**        | <code>string \| null</code>               | The initial Map mapTypeId. Defaults to &lt;code&gt;ROADMAP&lt;/code&gt;.                                                                                                                                                                                                                                                                                  |                    |       |
-| **`heading`**          | <code>number \| null</code>               | The heading for aerial imagery in degrees measured clockwise from cardinal direction North. Headings are snapped to the nearest available angle for which imagery is available.                                                                                                                                                                           |                    |       |
-| **`restriction`**      | <code>MapRestriction \| null</code>       | Defines a boundary that restricts the area of the map accessible to users. When set, a user can only pan and zoom while the camera view stays inside the limits of the boundary.                                                                                                                                                                          |                    |       |
+| Prop                   | Type                                      | Description                                                                                                                                            | Default            | Since |
+| ---------------------- | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------ | ----- |
+| **`width`**            | <code>number</code>                       | Override width for native map.                                                                                                                         |                    |       |
+| **`height`**           | <code>number</code>                       | Override height for native map.                                                                                                                        |                    |       |
+| **`x`**                | <code>number</code>                       | Override absolute x coordinate position for native map.                                                                                                |                    |       |
+| **`y`**                | <code>number</code>                       | Override absolute y coordinate position for native map.                                                                                                |                    |       |
+| **`center`**           | <code><a href="#latlng">LatLng</a></code> | Default location on the Earth towards which the camera points.                                                                                         |                    |       |
+| **`zoom`**             | <code>number</code>                       | Sets the zoom of the map.                                                                                                                              |                    |       |
+| **`androidLiteMode`**  | <code>boolean</code>                      | Enables image-based lite mode on Android.                                                                                                              | <code>false</code> |       |
+| **`devicePixelRatio`** | <code>number</code>                       | Override pixel ratio for native map.                                                                                                                   |                    |       |
+| **`mapId`**            | <code>string</code>                       | A map id associated with a specific map style or feature. [Use Map IDs](https://developers.google.com/maps/documentation/get-map-id) Only for Web.     |                    | 5.4.0 |
+| **`androidMapId`**     | <code>string</code>                       | A map id associated with a specific map style or feature. [Use Map IDs](https://developers.google.com/maps/documentation/get-map-id) Only for Android. |                    | 5.4.0 |
+| **`iOSMapId`**         | <code>string</code>                       | A map id associated with a specific map style or feature. [Use Map IDs](https://developers.google.com/maps/documentation/get-map-id) Only for iOS.     |                    | 5.4.0 |
 
 
 #### LatLng
@@ -1043,6 +1071,46 @@ An interface representing a pair of latitude and longitude coordinates.
 | Prop        | Type                |
 | ----------- | ------------------- |
 | **`mapId`** | <code>string</code> |
+
+
+#### GoogleMapConfig
+
+For web, all the javascript Google Maps options are available as
+GoogleMapConfig extends google.maps.MapOptions.
+For iOS and Android the following options from google.maps.MapOptions with the same signature are additionally available:
+- gestureHandling ('none' | 'auto')
+- heading
+- mapTypeId
+- maxZoom
+- minZoom
+- restriction
+- styles
+
+| Prop                                 | Type                                              | Description                                                                                                                                        |
+| ------------------------------------ | ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`isAccessibilityElementsEnabled`** | <code>boolean</code>                              | Show accessibility elements for overlay objects, such as <a href="#marker">Marker</a> and <a href="#polyline">Polyline</a>. Only available on iOS. |
+| **`isCompassEnabled`**               | <code>boolean</code>                              | Enables or disables the compass.                                                                                                                   |
+| **`isMyLocationButtonEnabled`**      | <code>boolean</code>                              | Sets whether a button should be displayed, which centers the camera to the users current position.                                                 |
+| **`isMyLocationEnabled`**            | <code>boolean</code>                              | Sets whether the My Location dot and accuracy circle is enabled.                                                                                   |
+| **`isIndoorMapsEnabled`**            | <code>boolean</code>                              | Sets whether indoor maps should be enabled. Only available on Android and iOS.                                                                     |
+| **`isRotateGesturesEnabled`**        | <code>boolean</code>                              | Sets the preference for whether rotate gestures should be enabled or disabled.                                                                     |
+| **`isTiltGesturesEnabled`**          | <code>boolean</code>                              | Sets the preference for whether tilt gestures should be enabled or disabled.                                                                       |
+| **`isToolbarEnabled`**               | <code>boolean</code>                              | Sets the preference for whether the Map Toolbar should be enabled or disabled. Only available on Android.                                          |
+| **`isTrafficLayerEnabled`**          | <code>boolean</code>                              | Turns the traffic layer on or off.                                                                                                                 |
+| **`isZoomGesturesEnabled`**          | <code>boolean</code>                              | Sets the preference for whether zoom gestures should be enabled or disabled.                                                                       |
+| **`padding`**                        | <code><a href="#mappadding">MapPadding</a></code> | Padding on the 'visible' region of the view.                                                                                                       |
+
+
+#### MapPadding
+
+Controls for setting padding on the 'visible' region of the view.
+
+| Prop         | Type                |
+| ------------ | ------------------- |
+| **`top`**    | <code>number</code> |
+| **`left`**   | <code>number</code> |
+| **`right`**  | <code>number</code> |
+| **`bottom`** | <code>number</code> |
 
 
 #### TileOverlay
@@ -1170,18 +1238,6 @@ Configuration properties for a Google Map Camera
 | **`angle`**             | <code>number</code>                       | The angle, in degrees, of the camera from the nadir (directly facing the Earth). The only allowed values are 0 and 45. | <code>0</code>     |
 | **`animate`**           | <code>boolean</code>                      | Animate the transition to the new Camera properties.                                                                   | <code>false</code> |
 | **`animationDuration`** | <code>number</code>                       | This configuration option is not being used.                                                                           |                    |
-
-
-#### MapPadding
-
-Controls for setting padding on the 'visible' region of the view.
-
-| Prop         | Type                |
-| ------------ | ------------------- |
-| **`top`**    | <code>number</code> |
-| **`left`**   | <code>number</code> |
-| **`right`**  | <code>number</code> |
-| **`bottom`** | <code>number</code> |
 
 
 #### CameraIdleCallbackData

--- a/plugin/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMap.kt
+++ b/plugin/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMap.kt
@@ -102,42 +102,6 @@ class CapacitorGoogleMap(
 
                 bridge.webView.bringToFront()
                 bridge.webView.setBackgroundColor(Color.TRANSPARENT)
-                if (config.styles != null) {
-                    googleMap?.setMapStyle(MapStyleOptions(config.styles!!))
-                }
-
-                if (config.maxZoom != null) {
-                    googleMap?.setMaxZoomPreference(config.maxZoom!!.toFloat())
-                }
-
-                if (config.minZoom != null) {
-                    googleMap?.setMinZoomPreference((config.minZoom!!.toFloat()))
-                }
-
-                if (config.mapTypeId != null) {
-                    when (config.mapTypeId!!) {
-                        "hybrid" -> googleMap?.mapType = GoogleMap.MAP_TYPE_HYBRID
-                        "roadmap" -> googleMap?.mapType = GoogleMap.MAP_TYPE_NORMAL
-                        "satellite" -> googleMap?.mapType = GoogleMap.MAP_TYPE_SATELLITE
-                        "terrain" -> googleMap?.mapType = GoogleMap.MAP_TYPE_TERRAIN
-                    }
-                }
-
-                if (config.restriction != null) {
-                    googleMap?.setLatLngBoundsForCameraTarget(config.restriction!!.latLngBounds)
-                }
-
-                if (config.heading != null) {
-                    googleMap?.cameraPosition?.let { cameraPosition ->
-                        googleMap?.animateCamera(
-                            CameraUpdateFactory.newCameraPosition(
-                                CameraPosition.Builder(cameraPosition)
-                                    .bearing(config.heading!!.toFloat())
-                                    .build()
-                            )
-                        )
-                    }
-                }
             }
         }
     }
@@ -183,6 +147,178 @@ class CapacitorGoogleMap(
                             this@CapacitorGoogleMap.id
                     )
             mapViewParent.bringToFront()
+        }
+    }
+
+    fun applyConfig(configObject: JSObject, callback: (error: GoogleMapsError?) -> Unit) {
+        try {
+            googleMap ?: throw GoogleMapNotAvailable()
+
+            CoroutineScope(Dispatchers.Main).launch {
+                if (configObject.has("gestureHandling")) {
+                    googleMap?.uiSettings?.setAllGesturesEnabled(configObject.getString("gestureHandling") != "none")
+                }
+
+                if (configObject.has("heading")) {
+                    googleMap?.cameraPosition?.let { cameraPosition ->
+                        googleMap?.animateCamera(
+                            CameraUpdateFactory.newCameraPosition(
+                                CameraPosition.Builder(cameraPosition)
+                                    .bearing(configObject.getDouble("heading")!!.toFloat())
+                                    .build()
+                            )
+                        )
+                    }
+                }
+
+                if (configObject.has("isCompassEnabled")) {
+                    googleMap?.uiSettings?.isCompassEnabled = configObject.getBool("isCompassEnabled") == true
+                }
+
+                if (configObject.has("isIndoorMapsEnabled")) {
+                    googleMap?.isIndoorEnabled = configObject.getBool("isIndoorMapsEnabled") == true
+                }
+
+                if (configObject.has("isMyLocationButtonEnabled")) {
+                    googleMap?.uiSettings?.isMyLocationButtonEnabled = configObject.getBool("isMyLocationButtonEnabled") == true
+                }
+
+                if (configObject.has("isMyLocationEnabled")) {
+                    @SuppressLint("MissingPermission")
+                    googleMap?.isMyLocationEnabled = configObject.getBool("isMyLocationEnabled") == true
+                }
+
+                if (configObject.has("isRotateGesturesEnabled")) {
+                    googleMap?.uiSettings?.isRotateGesturesEnabled =  configObject.getBool("isRotateGesturesEnabled") == true
+                }
+
+                if (configObject.has("isTiltGesturesEnabled")) {
+                    googleMap?.uiSettings?.isTiltGesturesEnabled = configObject.getBool("isTiltGesturesEnabled") == true
+                }
+
+                if (configObject.has("isToolbarEnabled")) {
+                    googleMap?.uiSettings?.isMapToolbarEnabled = configObject.getBool("isToolbarEnabled") == true
+                }
+
+                if (configObject.has("isTrafficLayerEnabled")) {
+                    googleMap?.isTrafficEnabled = configObject.getBool("isTrafficLayerEnabled") == true
+                }
+
+                if (configObject.has("isZoomGesturesEnabled")) {
+                    googleMap?.uiSettings?.isZoomGesturesEnabled = configObject.getBool("isZoomGesturesEnabled") == true
+                }
+
+                if (configObject.has("mapTypeId")) {
+                    setMapType(configObject.getString("mapTypeId"))
+                }
+
+                if (configObject.has("maxZoom")) {
+                    setMaxZoom(configObject.getDouble("maxZoom").toFloat())
+                }
+
+                if (configObject.has("minZoom")) {
+                    setMinZoom(configObject.getDouble("minZoom").toFloat())
+                }
+
+                if (configObject.has("padding")) {
+                    setPadding(configObject.getJSObject("padding"))
+                }
+
+                if (configObject.has("restriction")) {
+                    setRestriction(configObject.getJSObject("restriction"))
+                }
+
+                if (configObject.has("styles")) {
+                    googleMap?.setMapStyle(configObject.getString("styles")
+                        ?.let { MapStyleOptions(it) })
+                }
+
+                callback(null)
+            }
+        } catch (e: GoogleMapsError) {
+            callback(e)
+        }
+    }
+
+    private fun setMapType(mapTypeId: String?) {
+        val mapTypeInt: Int =
+            when (mapTypeId?.lowercase()) {
+                "normal" -> MAP_TYPE_NORMAL
+                "hybrid" -> MAP_TYPE_HYBRID
+                "satellite" -> MAP_TYPE_SATELLITE
+                "terrain" -> MAP_TYPE_TERRAIN
+                "none" -> MAP_TYPE_NONE
+                else -> {
+                    Log.w(
+                        "CapacitorGoogleMaps",
+                        "unknown mapView type '$mapTypeId'  Defaulting to normal."
+                    )
+                    MAP_TYPE_NORMAL
+                }
+            }
+
+        googleMap?.mapType = mapTypeInt
+    }
+
+    private fun setMaxZoom(maxZoom: Float) {
+        var minZoom = googleMap?.minZoomLevel
+        googleMap?.resetMinMaxZoomPreference()
+        if (minZoom != null) {
+            googleMap?.setMinZoomPreference(minZoom)
+        }
+        if (maxZoom != 0F) {
+            googleMap?.setMinZoomPreference(maxZoom)
+        }
+    }
+
+    private fun setMinZoom(minZoom: Float) {
+        var maxZoom = googleMap?.maxZoomLevel
+        googleMap?.resetMinMaxZoomPreference()
+        if (maxZoom != null) {
+            googleMap?.setMaxZoomPreference(maxZoom)
+        }
+        if (minZoom != 0F) {
+            googleMap?.setMinZoomPreference(minZoom)
+        }
+    }
+
+    private fun setPadding(paddingObj: JSObject?) {
+        if (paddingObj == null) {
+            googleMap?.setPadding(0, 0, 0, 0)
+        } else {
+            val padding = GoogleMapPadding(paddingObj)
+            val left = getScaledPixels(delegate.bridge, padding.left)
+            val top = getScaledPixels(delegate.bridge, padding.top)
+            val right = getScaledPixels(delegate.bridge, padding.right)
+            val bottom = getScaledPixels(delegate.bridge, padding.bottom)
+            googleMap?.setPadding(left, top, right, bottom)
+        }
+    }
+
+    private fun setRestriction(restrictionObj: JSObject?) {
+        var latLngBounds = restrictionObj?.getJSObject("latLngBounds")
+        var bounds: LatLngBounds? = null
+
+        if (latLngBounds != null) {
+            bounds = createLatLngBoundsFromGMSJS(latLngBounds)
+        }
+
+        googleMap?.resetMinMaxZoomPreference()
+        googleMap?.setLatLngBoundsForCameraTarget(null)
+
+        if (bounds != null) {
+            googleMap?.animateCamera(CameraUpdateFactory.newLatLngBounds(bounds, 0),
+                object : CancelableCallback {
+                    override fun onFinish() {
+                        val zoom = googleMap?.cameraPosition?.zoom
+                        if (zoom != null) {
+                            googleMap?.setMinZoomPreference(zoom)
+                        }
+                        googleMap?.setLatLngBoundsForCameraTarget(bounds)
+                    }
+                    override fun onCancel() {}
+                }
+            )
         }
     }
 
@@ -653,104 +789,6 @@ class CapacitorGoogleMap(
         }
     }
 
-    fun getMapType(callback: (type: String, error: GoogleMapsError?) -> Unit) {
-        try {
-            googleMap ?: throw GoogleMapNotAvailable()
-            CoroutineScope(Dispatchers.Main).launch {
-                val mapType: String = when (googleMap?.mapType) {
-                    MAP_TYPE_NORMAL -> "Normal"
-                    MAP_TYPE_HYBRID -> "Hybrid"
-                    MAP_TYPE_SATELLITE -> "Satellite"
-                    MAP_TYPE_TERRAIN -> "Terrain"
-                    MAP_TYPE_NONE -> "None"
-                    else -> {
-                        "Normal"
-                    }
-                }
-                callback(mapType, null);
-            }
-        }  catch (e: GoogleMapsError) {
-            callback("", e)
-        }
-    }
-
-    fun setMapType(mapType: String, callback: (error: GoogleMapsError?) -> Unit) {
-        try {
-            googleMap ?: throw GoogleMapNotAvailable()
-            CoroutineScope(Dispatchers.Main).launch {
-                val mapTypeInt: Int =
-                        when (mapType) {
-                            "Normal" -> MAP_TYPE_NORMAL
-                            "Hybrid" -> MAP_TYPE_HYBRID
-                            "Satellite" -> MAP_TYPE_SATELLITE
-                            "Terrain" -> MAP_TYPE_TERRAIN
-                            "None" -> MAP_TYPE_NONE
-                            else -> {
-                                Log.w(
-                                        "CapacitorGoogleMaps",
-                                        "unknown mapView type '$mapType'  Defaulting to normal."
-                                )
-                                MAP_TYPE_NORMAL
-                            }
-                        }
-
-                googleMap?.mapType = mapTypeInt
-                callback(null)
-            }
-        } catch (e: GoogleMapsError) {
-            callback(e)
-        }
-    }
-
-    fun enableIndoorMaps(enabled: Boolean, callback: (error: GoogleMapsError?) -> Unit) {
-        try {
-            googleMap ?: throw GoogleMapNotAvailable()
-            CoroutineScope(Dispatchers.Main).launch {
-                googleMap?.isIndoorEnabled = enabled
-                callback(null)
-            }
-        } catch (e: GoogleMapsError) {
-            callback(e)
-        }
-    }
-
-    fun enableTrafficLayer(enabled: Boolean, callback: (error: GoogleMapsError?) -> Unit) {
-        try {
-            googleMap ?: throw GoogleMapNotAvailable()
-            CoroutineScope(Dispatchers.Main).launch {
-                googleMap?.isTrafficEnabled = enabled
-                callback(null)
-            }
-        } catch (e: GoogleMapsError) {
-            callback(e)
-        }
-    }
-
-    @SuppressLint("MissingPermission")
-    fun enableCurrentLocation(enabled: Boolean, callback: (error: GoogleMapsError?) -> Unit) {
-        try {
-            googleMap ?: throw GoogleMapNotAvailable()
-            CoroutineScope(Dispatchers.Main).launch {
-                googleMap?.isMyLocationEnabled = enabled
-                callback(null)
-            }
-        } catch (e: GoogleMapsError) {
-            callback(e)
-        }
-    }
-
-    fun setPadding(padding: GoogleMapPadding, callback: (error: GoogleMapsError?) -> Unit) {
-        try {
-            googleMap ?: throw GoogleMapNotAvailable()
-            CoroutineScope(Dispatchers.Main).launch {
-                googleMap?.setPadding(padding.left, padding.top, padding.right, padding.bottom)
-                callback(null)
-            }
-        } catch (e: GoogleMapsError) {
-            callback(e)
-        }
-    }
-
     fun getMapBounds(): Rect {
         return Rect(
                 getScaledPixels(delegate.bridge, config.x),
@@ -767,6 +805,20 @@ class CapacitorGoogleMap(
     fun fitBounds(bounds: LatLngBounds, padding: Int) {
         val cameraUpdate = CameraUpdateFactory.newLatLngBounds(bounds, padding)
         googleMap?.animateCamera(cameraUpdate)
+    }
+
+    private fun createLatLngBoundsFromGMSJS(boundsObject: JSObject): LatLngBounds {
+        val southwestLatLng = LatLng(
+            boundsObject.getDouble("south"),
+            boundsObject.getDouble("west")
+        )
+
+        val northeastLatLng = LatLng(
+            boundsObject.getDouble("north"),
+            boundsObject.getDouble("east")
+        )
+
+        return LatLngBounds(southwestLatLng, northeastLatLng)
     }
 
     private fun getScaledPixels(bridge: Bridge, pixels: Int): Int {

--- a/plugin/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMapsPlugin.kt
+++ b/plugin/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMapsPlugin.kt
@@ -9,7 +9,6 @@ import android.view.View
 import com.getcapacitor.*
 import com.getcapacitor.annotation.CapacitorPlugin
 import com.getcapacitor.annotation.Permission
-import com.getcapacitor.annotation.PermissionCallback
 import com.google.android.gms.maps.MapsInitializer
 import com.google.android.gms.maps.OnMapsSdkInitializedCallback
 import com.google.android.gms.maps.model.LatLng
@@ -154,7 +153,40 @@ class CapacitorGoogleMapsPlugin : Plugin(), OnMapsSdkInitializedCallback {
             val newMap = CapacitorGoogleMap(id, config, this)
             maps[id] = newMap
 
-            call.resolve()
+            newMap.applyConfig(configObject,  { err ->
+                if (err != null) {
+                    throw err
+                }
+
+                call.resolve()
+            })
+        } catch (e: GoogleMapsError) {
+            handleError(call, e)
+        } catch (e: Exception) {
+            handleError(call, e)
+        }
+    }
+
+    @PluginMethod
+    fun update(call: PluginCall) {
+        try {
+            val id = call.getString("id")
+            id ?: throw InvalidMapIdError()
+
+            val map = maps[id]
+            map ?: throw MapNotFoundError()
+
+            val configObject =
+                call.getObject("config")
+                    ?: throw InvalidArgumentsError("config object is missing")
+
+            map.applyConfig(configObject,  { err ->
+                if (err != null) {
+                    throw err
+                }
+
+                call.resolve()
+            })
         } catch (e: GoogleMapsError) {
             handleError(call, e)
         } catch (e: Exception) {
@@ -713,160 +745,6 @@ class CapacitorGoogleMapsPlugin : Plugin(), OnMapsSdkInitializedCallback {
     }
 
     @PluginMethod
-    fun getMapType(call: PluginCall) {
-        try {
-            val id = call.getString("id")
-            id ?: throw InvalidMapIdError()
-
-            val map = maps[id]
-            map ?: throw MapNotFoundError()
-
-            map.getMapType() { type, err ->
-
-                if (err != null) {
-                    throw err
-                }
-                val data = JSObject()
-                data.put("type", type)
-                call.resolve(data)
-            }
-        } catch (e: GoogleMapsError) {
-            handleError(call, e)
-        } catch (e: Exception) {
-            handleError(call, e)
-        }
-    }
-
-    @PluginMethod
-    fun setMapType(call: PluginCall) {
-        try {
-            val id = call.getString("id")
-            id ?: throw InvalidMapIdError()
-
-            val map = maps[id]
-            map ?: throw MapNotFoundError()
-
-            val mapType =
-                    call.getString("mapType") ?: throw InvalidArgumentsError("mapType is missing")
-
-            map.setMapType(mapType) { err ->
-                if (err != null) {
-                    throw err
-                }
-
-                call.resolve()
-            }
-        } catch (e: GoogleMapsError) {
-            handleError(call, e)
-        } catch (e: Exception) {
-            handleError(call, e)
-        }
-    }
-
-    @PluginMethod
-    fun enableIndoorMaps(call: PluginCall) {
-        try {
-            val id = call.getString("id")
-            id ?: throw InvalidMapIdError()
-
-            val map = maps[id]
-            map ?: throw MapNotFoundError()
-
-            val enabled =
-                    call.getBoolean("enabled") ?: throw InvalidArgumentsError("enabled is missing")
-
-            map.enableIndoorMaps(enabled) { err ->
-                if (err != null) {
-                    throw err
-                }
-
-                call.resolve()
-            }
-        } catch (e: GoogleMapsError) {
-            handleError(call, e)
-        } catch (e: Exception) {
-            handleError(call, e)
-        }
-    }
-
-    @PluginMethod
-    fun enableTrafficLayer(call: PluginCall) {
-        try {
-            val id = call.getString("id")
-            id ?: throw InvalidMapIdError()
-
-            val map = maps[id]
-            map ?: throw MapNotFoundError()
-
-            val enabled =
-                    call.getBoolean("enabled") ?: throw InvalidArgumentsError("enabled is missing")
-
-            map.enableTrafficLayer(enabled) { err ->
-                if (err != null) {
-                    throw err
-                }
-
-                call.resolve()
-            }
-        } catch (e: GoogleMapsError) {
-            handleError(call, e)
-        } catch (e: Exception) {
-            handleError(call, e)
-        }
-    }
-
-    @PluginMethod
-    fun enableCurrentLocation(call: PluginCall) {
-        if (getPermissionState(LOCATION) != PermissionState.GRANTED) {
-            requestAllPermissions(call, "enableCurrentLocationCallback")
-        } else {
-            internalEnableCurrentLocation(call)
-        }
-    }
-
-    @PermissionCallback
-    fun enableCurrentLocationCallback(call: PluginCall) {
-        if (getPermissionState(LOCATION) == PermissionState.GRANTED) {
-            internalEnableCurrentLocation(call)
-        } else {
-            call.reject("location permission was denied")
-        }
-    }
-
-    @PluginMethod
-    fun setPadding(call: PluginCall) {
-        try {
-            val id = call.getString("id")
-            id ?: throw InvalidMapIdError()
-
-            val map = maps[id]
-            map ?: throw MapNotFoundError()
-
-            val paddingObj =
-                    call.getObject("padding") ?: throw InvalidArgumentsError("padding is missing")
-
-            val padding = GoogleMapPadding(paddingObj)
-
-            map.setPadding(padding) { err ->
-                if (err != null) {
-                    throw err
-                }
-
-                call.resolve()
-            }
-        } catch (e: GoogleMapsError) {
-            handleError(call, e)
-        } catch (e: Exception) {
-            handleError(call, e)
-        }
-    }
-
-    @PluginMethod
-    fun enableAccessibilityElements(call: PluginCall) {
-        call.unavailable("this call is not available on android")
-    }
-
-    @PluginMethod
     fun onScroll(call: PluginCall) {
         try {
             val id = call.getString("id")
@@ -1057,31 +935,6 @@ class CapacitorGoogleMapsPlugin : Plugin(), OnMapsSdkInitializedCallback {
         val northeastLatLng = createLatLng(northeastObject)
 
         return LatLngBounds(southwestLatLng, northeastLatLng)
-    }
-
-    private fun internalEnableCurrentLocation(call: PluginCall) {
-        try {
-            val id = call.getString("id")
-            id ?: throw InvalidMapIdError()
-
-            val map = maps[id]
-            map ?: throw MapNotFoundError()
-
-            val enabled =
-                    call.getBoolean("enabled") ?: throw InvalidArgumentsError("enabled is missing")
-
-            map.enableCurrentLocation(enabled) { err ->
-                if (err != null) {
-                    throw err
-                }
-
-                call.resolve()
-            }
-        } catch (e: GoogleMapsError) {
-            handleError(call, e)
-        } catch (e: Exception) {
-            handleError(call, e)
-        }
     }
 
     fun notify(event: String, data: JSObject) {

--- a/plugin/android/src/main/java/com/capacitorjs/plugins/googlemaps/GoogleMapConfig.kt
+++ b/plugin/android/src/main/java/com/capacitorjs/plugins/googlemaps/GoogleMapConfig.kt
@@ -3,7 +3,6 @@ package com.capacitorjs.plugins.googlemaps
 import com.google.android.gms.maps.GoogleMapOptions
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
-import com.google.android.gms.maps.model.LatLngBounds
 import org.json.JSONObject
 
 class GoogleMapConfig(fromJSONObject: JSONObject) {
@@ -11,17 +10,9 @@ class GoogleMapConfig(fromJSONObject: JSONObject) {
     var height: Int = 0
     var x: Int = 0
     var y: Int = 0
-    var center: LatLng = LatLng(0.0, 0.0)
     var googleMapOptions: GoogleMapOptions? = null
-    var zoom: Int = 0
-    var liteMode: Boolean = false
     var devicePixelRatio: Float = 1.00f
-    var styles: String? = null
-    var mapId: String? = null
-    var minZoom: Int? = null
-    var maxZoom: Int? = null
     var mapTypeId: String? = null
-    var restriction: GoogleMapConfigRestriction? = null
     var heading: Double? = null
 
     init {
@@ -73,10 +64,6 @@ class GoogleMapConfig(fromJSONObject: JSONObject) {
             )
         }
 
-        liteMode =
-                fromJSONObject.has("androidLiteMode") &&
-                        fromJSONObject.getBoolean("androidLiteMode")
-
         width = fromJSONObject.getInt("width")
         height = fromJSONObject.getInt("height")
         x = fromJSONObject.getInt("x")
@@ -90,27 +77,20 @@ class GoogleMapConfig(fromJSONObject: JSONObject) {
             tempMinZoom = tempMaxZoom.also { tempMaxZoom = tempMinZoom }
         }
 
-        minZoom = tempMinZoom
-        maxZoom = tempMaxZoom
-
-        zoom = tempZoom.coerceIn(
-            tempMinZoom ?: Int.MIN_VALUE,
-            tempMaxZoom ?: Int.MAX_VALUE
-        )
-
         mapTypeId = fromJSONObject.optString("mapTypeId").takeIf { fromJSONObject.has("mapTypeId") }
 
         val lat = centerJSONObject.getDouble("lat")
         val lng = centerJSONObject.getDouble("lng")
-        center = LatLng(lat, lng)
-
+        val center = LatLng(lat, lng)
+        val zoom = tempZoom.coerceIn(
+            tempMinZoom ?: Int.MIN_VALUE,
+            tempMaxZoom ?: Int.MAX_VALUE
+        )
+        val mapId = fromJSONObject.getString("androidMapId")
+        val liteMode =
+            fromJSONObject.has("androidLiteMode") &&
+                    fromJSONObject.getBoolean("androidLiteMode")
         val cameraPosition = CameraPosition(center, zoom.toFloat(), 0.0F, 0.0F)
-
-        styles = fromJSONObject.getString("styles")
-
-        mapId = fromJSONObject.getString("androidMapId")
-
-        restriction = fromJSONObject.optJSONObject("restriction")?.let { GoogleMapConfigRestriction(it) }
 
         heading = fromJSONObject.optDouble("heading").takeIf { fromJSONObject.has("heading") }
 
@@ -118,48 +98,5 @@ class GoogleMapConfig(fromJSONObject: JSONObject) {
         if (mapId != null) {
             googleMapOptions?.mapId(mapId!!)
         }
-    }
-}
-
-class GoogleMapConfigRestriction(fromJSONObject: JSONObject) {
-    var latLngBounds: LatLngBounds
-
-    init {
-        if (!fromJSONObject.has("latLngBounds")) {
-            throw InvalidArgumentsError(
-                "GoogleMapConfigRestriction object is missing the required 'latLngBounds' property"
-            )
-        }
-        val latLngBoundsObj = fromJSONObject.getJSONObject("latLngBounds")
-
-        if (!latLngBoundsObj.has("north")) {
-            throw InvalidArgumentsError(
-                "GoogleMapConfigRestriction object is missing the required 'latLngBounds.north' property"
-            )
-        }
-        if (!latLngBoundsObj.has("south")) {
-            throw InvalidArgumentsError(
-                "GoogleMapConfigRestriction object is missing the required 'latLngBounds.south' property"
-            )
-        }
-        if (!latLngBoundsObj.has("east")) {
-            throw InvalidArgumentsError(
-                "GoogleMapConfigRestriction object is missing the required 'latLngBounds.east' property"
-            )
-        }
-        if (!latLngBoundsObj.has("west")) {
-            throw InvalidArgumentsError(
-                "GoogleMapConfigRestriction object is missing the required 'latLngBounds.west' property"
-            )
-        }
-        val north = latLngBoundsObj.getDouble("north")
-        val south = latLngBoundsObj.getDouble("south")
-        val east = latLngBoundsObj.getDouble("east")
-        val west = latLngBoundsObj.getDouble("west")
-
-        latLngBounds = LatLngBounds(
-            LatLng(south, west),
-            LatLng(north, east)
-        )
     }
 }

--- a/plugin/ios/Sources/CapacitorGoogleMapsPlugin/GoogleMapConfig.swift
+++ b/plugin/ios/Sources/CapacitorGoogleMapsPlugin/GoogleMapConfig.swift
@@ -1,6 +1,5 @@
 import Foundation
 import Capacitor
-import GoogleMaps
 
 public struct GoogleMapConfig: Codable {
     let width: Double
@@ -9,13 +8,7 @@ public struct GoogleMapConfig: Codable {
     let y: Double
     let center: LatLng
     let zoom: Double
-    let styles: String?
     var mapId: String?
-    let mapTypeId: String?
-    let maxZoom: Double?
-    let minZoom: Double?
-    let restriction: GoogleMapConfigRestriction?
-    let heading: Double?
 
     init(fromJSObject: JSObject) throws {
         guard let width = fromJSObject["width"] as? Double else {
@@ -51,23 +44,14 @@ public struct GoogleMapConfig: Codable {
         self.x = x
         self.y = y
         self.center = LatLng(lat: lat, lng: lng)
-        if let stylesArray = fromJSObject["styles"] as? JSArray, let jsonData = try? JSONSerialization.data(withJSONObject: stylesArray, options: []) {
-            self.styles = String(data: jsonData, encoding: .utf8)
-        } else {
-            self.styles = nil
-        }
 
         self.mapId = fromJSObject["iOSMapId"] as? String
-
-        self.mapTypeId = fromJSObject["mapTypeId"] as? String
 
         var maxZoom = fromJSObject["maxZoom"] as? Double
         var minZoom = fromJSObject["minZoom"] as? Double
         if let unwrappedMinZoom = minZoom, let unwrappedMaxZoom = maxZoom, unwrappedMinZoom > unwrappedMaxZoom {
             swap(&minZoom, &maxZoom)
         }
-        self.minZoom = minZoom
-        self.maxZoom = maxZoom
 
         if let maxZoom, zoom > maxZoom {
             self.zoom = maxZoom
@@ -76,75 +60,5 @@ public struct GoogleMapConfig: Codable {
         } else {
             self.zoom = zoom
         }
-
-        if let restrictionObj = fromJSObject["restriction"] as? JSObject {
-            self.restriction = try GoogleMapConfigRestriction(fromJSObject: restrictionObj)
-        } else {
-            self.restriction = nil
-        }
-
-        self.heading = fromJSObject["heading"] as? Double
-    }
-}
-
-public struct GoogleMapConfigRestriction: Codable {
-    let latLngBounds: GMSCoordinateBounds
-
-    init(fromJSObject: JSObject) throws {
-        guard let latLngBoundsObj = fromJSObject["latLngBounds"] as? JSObject else {
-            throw GoogleMapErrors.invalidArguments("GoogleMapConfigRestriction object is missing the required 'latLngBounds' property")
-        }
-
-        guard let north = latLngBoundsObj["north"] as? Double else {
-            throw GoogleMapErrors.invalidArguments("GoogleMapConfigRestriction object is missing the required 'latLngBounds.north' property")
-        }
-
-        guard let south = latLngBoundsObj["south"] as? Double else {
-            throw GoogleMapErrors.invalidArguments("GoogleMapConfigRestriction object is missing the required 'latLngBounds.south' property")
-        }
-
-        guard let east = latLngBoundsObj["east"] as? Double else {
-            throw GoogleMapErrors.invalidArguments("GoogleMapConfigRestriction object is missing the required 'latLngBounds.east' property")
-        }
-
-        guard let west = latLngBoundsObj["west"] as? Double else {
-            throw GoogleMapErrors.invalidArguments("GoogleMapConfigRestriction object is missing the required 'latLngBounds.west' property")
-        }
-
-        let southWest = CLLocationCoordinate2D(latitude: south, longitude: west)
-        let northEast = CLLocationCoordinate2D(latitude: north, longitude: east)
-        self.latLngBounds = GMSCoordinateBounds(coordinate: southWest, coordinate: northEast)
-    }
-
-    enum CodingKeys: String, CodingKey {
-        case latLngBounds
-    }
-
-    struct LatLngBounds: Codable {
-        let north: CLLocationDegrees
-        let south: CLLocationDegrees
-        let east: CLLocationDegrees
-        let west: CLLocationDegrees
-    }
-
-    public func encode(to encoder: any Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-
-        let latLngBounds = LatLngBounds(
-            north: self.latLngBounds.northEast.latitude,
-            south: self.latLngBounds.southWest.latitude,
-            east: self.latLngBounds.northEast.longitude,
-            west: self.latLngBounds.southWest.longitude
-        )
-        try container.encode(latLngBounds, forKey: .latLngBounds)
-    }
-
-    public init(from decoder: any Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-
-        let latLngBounds = try container.decode(LatLngBounds.self, forKey: .latLngBounds)
-        let southWest = CLLocationCoordinate2D(latitude: latLngBounds.south, longitude: latLngBounds.west)
-        let northEast = CLLocationCoordinate2D(latitude: latLngBounds.north, longitude: latLngBounds.east)
-        self.latLngBounds = GMSCoordinateBounds(coordinate: southWest, coordinate: northEast)
     }
 }

--- a/plugin/src/definitions.ts
+++ b/plugin/src/definitions.ts
@@ -147,9 +147,82 @@ export interface StyleSpan {
 /**
  * For web, all the javascript Google Maps options are available as
  * GoogleMapConfig extends google.maps.MapOptions.
- * For iOS and Android only the config options declared on GoogleMapConfig are available.
+ * For iOS and Android the following options from google.maps.MapOptions with the same signature are additionally available:
+ * - gestureHandling ('none' | 'auto')
+ * - heading
+ * - mapTypeId
+ * - maxZoom
+ * - minZoom
+ * - restriction
+ * - styles
  */
 export interface GoogleMapConfig extends google.maps.MapOptions {
+  /**
+   * Show accessibility elements for overlay objects, such as Marker and Polyline.
+   *
+   * Only available on iOS.
+   */
+  isAccessibilityElementsEnabled?: boolean;
+  /**
+   * Enables or disables the compass.
+   */
+  isCompassEnabled?: boolean;
+  /**
+   * Sets whether a button should be displayed, which centers the camera to the users current position.
+   */
+  isMyLocationButtonEnabled?: boolean;
+  /**
+   * Sets whether the My Location dot and accuracy circle is enabled.
+   */
+  isMyLocationEnabled?: boolean;
+  /**
+   * Sets whether indoor maps should be enabled.
+   *
+   * Only available on Android and iOS.
+   */
+  isIndoorMapsEnabled?: boolean;
+  /**
+   * Sets the preference for whether rotate gestures should be enabled or disabled.
+   */
+  isRotateGesturesEnabled?: boolean;
+  /**
+   * Sets the preference for whether tilt gestures should be enabled or disabled.
+   */
+  isTiltGesturesEnabled?: boolean;
+  /**
+   * Sets the preference for whether the Map Toolbar should be enabled or disabled.
+   *
+   * Only available on Android.
+   */
+  isToolbarEnabled?: boolean;
+  /**
+   * Turns the traffic layer on or off.
+   */
+  isTrafficLayerEnabled?: boolean;
+  /**
+   * Sets the preference for whether zoom gestures should be enabled or disabled.
+   */
+  isZoomGesturesEnabled?: boolean;
+  /**
+   * Padding on the 'visible' region of the view.
+   */
+  padding?: MapPadding;
+}
+
+/**
+ * For web, all the javascript Google Maps options are available as
+ * GoogleMapCreateConfig extends google.maps.MapOptions.
+ * For iOS and Android the following options from google.maps.MapOptions with the same signature are additionally available:
+ * - gestureHandling ('none' | 'auto')
+ * - heading
+ * - mapTypeId
+ * - maxZoom
+ * - minZoom
+ * - restriction
+ * - styles
+ * - zoom
+ */
+export interface GoogleMapCreateConfig extends GoogleMapConfig {
   /**
    * Override width for native map.
    */
@@ -185,14 +258,6 @@ export interface GoogleMapConfig extends google.maps.MapOptions {
    */
   devicePixelRatio?: number;
   /**
-   * Styles to apply to each of the default map types. Note that for
-   * satellite, hybrid and terrain modes,
-   * these styles will only apply to labels and geometry.
-   *
-   * @since 4.3.0
-   */
-  styles?: google.maps.MapTypeStyle[] | null;
-  /**
    * A map id associated with a specific map style or feature.
    *
    * [Use Map IDs](https://developers.google.com/maps/documentation/get-map-id)
@@ -222,40 +287,6 @@ export interface GoogleMapConfig extends google.maps.MapOptions {
    * @since 5.4.0
    */
   iOSMapId?: string;
-  /**
-   * The maximum zoom level which will be displayed on the map. If omitted, or
-   * set to <code>null</code>, the maximum zoom from the current map type is
-   * used instead. Valid zoom values are numbers from zero up to the supported
-   * <a
-   * href="https://developers.google.com/maps/documentation/javascript/maxzoom">maximum
-   * zoom level</a>.
-   */
-  maxZoom?: number | null;
-  /**
-   * The minimum zoom level which will be displayed on the map. If omitted, or
-   * set to <code>null</code>, the minimum zoom from the current map type is
-   * used instead. Valid zoom values are numbers from zero up to the supported
-   * <a
-   * href="https://developers.google.com/maps/documentation/javascript/maxzoom">maximum
-   * zoom level</a>.
-   */
-  minZoom?: number | null;
-  /**
-   * The initial Map mapTypeId. Defaults to <code>ROADMAP</code>.
-   */
-  mapTypeId?: string | null;
-  /**
-   * The heading for aerial imagery in degrees measured clockwise from
-   * cardinal direction North. Headings are snapped to the nearest available
-   * angle for which imagery is available.
-   */
-  heading?: number | null;
-  /**
-   * Defines a boundary that restricts the area of the map accessible to
-   * users. When set, a user can only pan and zoom while the camera view stays
-   * inside the limits of the boundary.
-   */
-  restriction?: google.maps.MapRestriction | null;
 }
 
 /**

--- a/plugin/src/implementation.ts
+++ b/plugin/src/implementation.ts
@@ -7,12 +7,11 @@ import type {
   GoogleMapConfig,
   LatLng,
   LatLngBounds,
-  MapPadding,
-  MapType,
   Marker,
   Polygon,
   Polyline,
   TileOverlay,
+  GoogleMapCreateConfig,
 } from './definitions';
 
 /**
@@ -30,7 +29,7 @@ export interface CreateMapArgs {
   /**
    * The initial configuration settings for the map.
    */
-  config: GoogleMapConfig;
+  config: GoogleMapCreateConfig;
   /**
    * The DOM element that the Google Map View will be mounted on which determines size and positioning.
    */
@@ -53,6 +52,11 @@ export interface CreateMapArgs {
    * Only available for web.
    */
   language?: string;
+}
+
+export interface UpdateMapArgs {
+  id: string;
+  config: GoogleMapConfig;
 }
 
 export interface DestroyMapArgs {
@@ -108,16 +112,6 @@ export interface CameraArgs {
   config: CameraConfig;
 }
 
-export interface MapTypeArgs {
-  id: string;
-  mapType: MapType;
-}
-
-export interface IndoorMapArgs {
-  id: string;
-  enabled: boolean;
-}
-
 export interface RemoveTileOverlayArgs {
   id: string;
   tileOverlayId: string;
@@ -128,25 +122,11 @@ export interface AddTileOverlayArgs {
   tileOverlay: TileOverlay;
 }
 
-export interface TrafficLayerArgs {
-  id: string;
-  enabled: boolean;
-}
-
 export interface AccElementsArgs {
   id: string;
   enabled: boolean;
 }
 
-export interface PaddingArgs {
-  id: string;
-  padding: MapPadding;
-}
-
-export interface CurrentLocArgs {
-  id: string;
-  enabled: boolean;
-}
 export interface AddMarkersArgs {
   id: string;
   markers: Marker[];
@@ -182,6 +162,7 @@ export interface FitBoundsArgs {
 
 export interface CapacitorGoogleMapsPlugin extends Plugin {
   create(options: CreateMapArgs): Promise<void>;
+  update(options: UpdateMapArgs): Promise<void>;
   enableTouch(args: { id: string }): Promise<void>;
   disableTouch(args: { id: string }): Promise<void>;
   addTileOverlay(args: AddTileOverlayArgs): Promise<{ id: string }>;
@@ -200,13 +181,6 @@ export interface CapacitorGoogleMapsPlugin extends Plugin {
   disableClustering(args: { id: string }): Promise<void>;
   destroy(args: DestroyMapArgs): Promise<void>;
   setCamera(args: CameraArgs): Promise<void>;
-  getMapType(args: { id: string }): Promise<{ type: string }>;
-  setMapType(args: MapTypeArgs): Promise<void>;
-  enableIndoorMaps(args: IndoorMapArgs): Promise<void>;
-  enableTrafficLayer(args: TrafficLayerArgs): Promise<void>;
-  enableAccessibilityElements(args: AccElementsArgs): Promise<void>;
-  enableCurrentLocation(args: CurrentLocArgs): Promise<void>;
-  setPadding(args: PaddingArgs): Promise<void>;
   onScroll(args: MapBoundsArgs): Promise<void>;
   onResize(args: MapBoundsArgs): Promise<void>;
   onDisplay(args: MapBoundsArgs): Promise<void>;

--- a/plugin/src/map.ts
+++ b/plugin/src/map.ts
@@ -20,6 +20,7 @@ import type {
   Polyline,
   PolylineCallbackData,
   TileOverlay,
+  GoogleMapConfig,
 } from './definitions';
 import { LatLngBounds, MapType } from './definitions';
 import type { CreateMapArgs } from './implementation';
@@ -27,6 +28,8 @@ import { CapacitorGoogleMaps } from './implementation';
 
 export interface GoogleMapInterface {
   create(options: CreateMapArgs, callback?: MapListenerCallback<MapReadyCallbackData>): Promise<GoogleMap>;
+  update(config: GoogleMapConfig): Promise<void>;
+  getOptions(): GoogleMapConfig | null;
   enableTouch(): Promise<void>;
   disableTouch(): Promise<void>;
   enableClustering(
@@ -52,13 +55,32 @@ export interface GoogleMapInterface {
   setCamera(config: CameraConfig): Promise<void>;
   /**
    * Get current map type
+   * @deprecated This method will be removed in v7. Use {@link #update()} instead.
    */
   getMapType(): Promise<MapType>;
+  /**
+   * @deprecated This method will be removed in v7. Use {@link #update()} instead.
+   */
   setMapType(mapType: MapType): Promise<void>;
+  /**
+   * @deprecated This method will be removed in v7. Use {@link #update()} instead.
+   */
   enableIndoorMaps(enabled: boolean): Promise<void>;
+  /**
+   * @deprecated This method will be removed in v7. Use {@link #update()} instead.
+   */
   enableTrafficLayer(enabled: boolean): Promise<void>;
+  /**
+   * @deprecated This method will be removed in v7. Use {@link #update()} instead.
+   */
   enableAccessibilityElements(enabled: boolean): Promise<void>;
+  /**
+   * @deprecated This method will be removed in v7. Use {@link #update()} instead.
+   */
   enableCurrentLocation(enabled: boolean): Promise<void>;
+  /**
+   * @deprecated This method will be removed in v7. Use {@link #update()} instead.
+   */
   setPadding(padding: MapPadding): Promise<void>;
   /**
    * Get the map's current viewport latitude and longitude bounds.
@@ -116,6 +138,7 @@ export class GoogleMap {
   private id: string;
   private element: HTMLElement | null = null;
   private resizeObserver: ResizeObserver | null = null;
+  private config: GoogleMapConfig | null = null;
 
   private onBoundsChangedListener?: PluginListenerHandle;
   private onCameraIdleListener?: PluginListenerHandle;
@@ -149,6 +172,7 @@ export class GoogleMap {
     callback?: MapListenerCallback<MapReadyCallbackData>,
   ): Promise<GoogleMap> {
     const newMap = new GoogleMap(options.id);
+    newMap.config = options.config;
 
     if (!options.element) {
       throw new Error('container element is required');
@@ -286,6 +310,34 @@ export class GoogleMap {
         resolve(elementBounds);
       }
     });
+  }
+
+  /**
+   * Update map options
+   *
+   * @returns void
+   */
+  async update(config: GoogleMapConfig): Promise<void> {
+    Object.assign(this.config as any, config);
+
+    // Convert restriction latLngBounds to LatLngBoundsLiteral if its in LatLngBounds format
+    if (config.restriction?.latLngBounds && (config.restriction.latLngBounds as any)?.toJSON) {
+      config.restriction.latLngBounds = (config.restriction.latLngBounds as google.maps.LatLngBounds).toJSON();
+    }
+
+    return CapacitorGoogleMaps.update({
+      id: this.id,
+      config,
+    });
+  }
+
+  /**
+   * Get map options
+   *
+   * @returns void
+   */
+  getOptions(): GoogleMapConfig | null {
+    return this.config;
   }
 
   /**
@@ -500,52 +552,64 @@ export class GoogleMap {
     });
   }
 
+  /**
+   * @deprecated This method will be removed in v7. Use {@link #update()} instead.
+   */
   async getMapType(): Promise<MapType> {
-    const { type } = await CapacitorGoogleMaps.getMapType({ id: this.id });
-    return MapType[type as keyof typeof MapType];
+    return Promise.resolve(MapType[this.getOptions()?.mapTypeId as keyof typeof MapType]);
   }
 
   /**
    * Sets the type of map tiles that should be displayed.
+   * @deprecated This method will be removed in v7. Use {@link #update()} instead.
    *
    * @param mapType
    * @returns
    */
   async setMapType(mapType: MapType): Promise<void> {
-    return CapacitorGoogleMaps.setMapType({
+    return CapacitorGoogleMaps.update({
       id: this.id,
-      mapType,
+      config: {
+        mapTypeId: mapType,
+      },
     });
   }
 
   /**
    * Sets whether indoor maps are shown, where available.
+   * @deprecated This method will be removed in v7. Use {@link #update()} instead.
    *
    * @param enabled
    * @returns
    */
   async enableIndoorMaps(enabled: boolean): Promise<void> {
-    return CapacitorGoogleMaps.enableIndoorMaps({
+    return CapacitorGoogleMaps.update({
       id: this.id,
-      enabled,
+      config: {
+        isIndoorMapsEnabled: enabled,
+      },
     });
   }
 
   /**
    * Controls whether the map is drawing traffic data, if available.
+   * @deprecated This method will be removed in v7. Use {@link #update()} instead.
    *
    * @param enabled
    * @returns
    */
   async enableTrafficLayer(enabled: boolean): Promise<void> {
-    return CapacitorGoogleMaps.enableTrafficLayer({
+    return CapacitorGoogleMaps.update({
       id: this.id,
-      enabled,
+      config: {
+        isTrafficLayerEnabled: enabled,
+      },
     });
   }
 
   /**
    * Show accessibility elements for overlay objects, such as Marker and Polyline.
+   * @deprecated This method will be removed in v7. Use {@link #update()} instead.
    *
    * Only available on iOS.
    *
@@ -553,35 +617,43 @@ export class GoogleMap {
    * @returns
    */
   async enableAccessibilityElements(enabled: boolean): Promise<void> {
-    return CapacitorGoogleMaps.enableAccessibilityElements({
+    return CapacitorGoogleMaps.update({
       id: this.id,
-      enabled,
+      config: {
+        isAccessibilityElementsEnabled: enabled,
+      },
     });
   }
 
   /**
    * Set whether the My Location dot and accuracy circle is enabled.
+   * @deprecated This method will be removed in v7. Use {@link #update()} instead.
    *
    * @param enabled
    * @returns
    */
   async enableCurrentLocation(enabled: boolean): Promise<void> {
-    return CapacitorGoogleMaps.enableCurrentLocation({
+    return CapacitorGoogleMaps.update({
       id: this.id,
-      enabled,
+      config: {
+        isMyLocationEnabled: enabled,
+      },
     });
   }
 
   /**
    * Set padding on the 'visible' region of the view.
+   * @deprecated This method will be removed in v7. Use {@link #update()} instead.
    *
    * @param padding
    * @returns
    */
   async setPadding(padding: MapPadding): Promise<void> {
-    return CapacitorGoogleMaps.setPadding({
+    return CapacitorGoogleMaps.update({
       id: this.id,
-      padding,
+      config: {
+        padding,
+      },
     });
   }
 

--- a/plugin/src/web.ts
+++ b/plugin/src/web.ts
@@ -2,8 +2,8 @@ import { WebPlugin } from '@capacitor/core';
 import type { Cluster, onClusterClickHandler } from '@googlemaps/markerclusterer';
 import { MarkerClusterer, SuperClusterAlgorithm } from '@googlemaps/markerclusterer';
 
-import type { Marker, TileOverlay } from './definitions';
-import { MapType, LatLngBounds } from './definitions';
+import type { Marker, MapPadding, GoogleMapConfig, TileOverlay } from './definitions';
+import { LatLngBounds } from './definitions';
 import type {
   AddTileOverlayArgs,
   AddMarkerArgs,
@@ -11,12 +11,8 @@ import type {
   AddMarkersArgs,
   CapacitorGoogleMapsPlugin,
   CreateMapArgs,
-  CurrentLocArgs,
   DestroyMapArgs,
-  MapTypeArgs,
-  PaddingArgs,
   RemoveMarkerArgs,
-  TrafficLayerArgs,
   RemoveMarkersArgs,
   MapBoundsContainsArgs,
   EnableClusteringArgs,
@@ -29,35 +25,36 @@ import type {
   AddPolylinesArgs,
   RemovePolylinesArgs,
   RemoveTileOverlayArgs,
+  UpdateMapArgs,
 } from './implementation';
+
+class MapInstance {
+  element!: HTMLElement;
+  map!: google.maps.Map;
+  markers: {
+    [id: string]: google.maps.marker.AdvancedMarkerElement;
+  } = {};
+  tileOverlays: {
+    [id: string]: google.maps.ImageMapType;
+  } = {};
+  polygons: {
+    [id: string]: google.maps.Polygon;
+  } = {};
+  circles: {
+    [id: string]: google.maps.Circle;
+  } = {};
+  polylines: {
+    [id: string]: google.maps.Polyline;
+  } = {};
+  markerClusterer?: MarkerClusterer;
+  trafficLayer?: google.maps.TrafficLayer;
+}
 
 export class CapacitorGoogleMapsWeb extends WebPlugin implements CapacitorGoogleMapsPlugin {
   private gMapsRef: google.maps.MapsLibrary | undefined = undefined;
   private AdvancedMarkerElement: typeof google.maps.marker.AdvancedMarkerElement | undefined = undefined;
   private PinElement: typeof google.maps.marker.PinElement | undefined = undefined;
-  private maps: {
-    [id: string]: {
-      element: HTMLElement;
-      map: google.maps.Map;
-      markers: {
-        [id: string]: google.maps.marker.AdvancedMarkerElement;
-      };
-      tileOverlays: {
-        [id: string]: google.maps.ImageMapType;
-      };
-      polygons: {
-        [id: string]: google.maps.Polygon;
-      };
-      circles: {
-        [id: string]: google.maps.Circle;
-      };
-      polylines: {
-        [id: string]: google.maps.Polyline;
-      };
-      markerClusterer?: MarkerClusterer;
-      trafficLayer?: google.maps.TrafficLayer;
-    };
-  } = {};
+  private maps: { [id: string]: MapInstance } = {};
   private currMarkerId = 0;
   private currTileOverlayId = 0;
   private currPolygonId = 0;
@@ -159,80 +156,8 @@ export class CapacitorGoogleMapsWeb extends WebPlugin implements CapacitorGoogle
     });
   }
 
-  async getMapType(_args: { id: string }): Promise<{ type: string }> {
-    let type = this.maps[_args.id].map.getMapTypeId();
-    if (type !== undefined) {
-      if (type === 'roadmap') {
-        type = MapType.Normal;
-      }
-      return { type: `${type.charAt(0).toUpperCase()}${type.slice(1)}` };
-    }
-    throw new Error('Map type is undefined');
-  }
-
-  async setMapType(_args: MapTypeArgs): Promise<void> {
-    let mapType = _args.mapType.toLowerCase();
-    if (_args.mapType === MapType.Normal) {
-      mapType = 'roadmap';
-    }
-    this.maps[_args.id].map.setMapTypeId(mapType);
-  }
-
-  async enableIndoorMaps(): Promise<void> {
-    throw new Error('Method not supported on web.');
-  }
-
-  async enableTrafficLayer(_args: TrafficLayerArgs): Promise<void> {
-    const trafficLayer = this.maps[_args.id].trafficLayer ?? new google.maps.TrafficLayer();
-
-    if (_args.enabled) {
-      trafficLayer.setMap(this.maps[_args.id].map);
-      this.maps[_args.id].trafficLayer = trafficLayer;
-    } else if (this.maps[_args.id].trafficLayer) {
-      trafficLayer.setMap(null);
-      this.maps[_args.id].trafficLayer = undefined;
-    }
-  }
-
-  async enableAccessibilityElements(): Promise<void> {
-    throw new Error('Method not supported on web.');
-  }
-
   dispatchMapEvent(): Promise<void> {
     throw new Error('Method not supported on web.');
-  }
-
-  async enableCurrentLocation(_args: CurrentLocArgs): Promise<void> {
-    if (_args.enabled) {
-      if (navigator.geolocation) {
-        navigator.geolocation.getCurrentPosition(
-          (position: GeolocationPosition) => {
-            const pos = {
-              lat: position.coords.latitude,
-              lng: position.coords.longitude,
-            };
-
-            this.maps[_args.id].map.setCenter(pos);
-
-            this.notifyListeners('onMyLocationButtonClick', {});
-
-            this.notifyListeners('onMyLocationClick', {});
-          },
-          () => {
-            throw new Error('Geolocation not supported on web browser.');
-          },
-        );
-      } else {
-        throw new Error('Geolocation not supported on web browser.');
-      }
-    }
-  }
-  async setPadding(_args: PaddingArgs): Promise<void> {
-    const bounds = this.maps[_args.id].map.getBounds();
-
-    if (bounds !== undefined) {
-      this.maps[_args.id].map.fitBounds(bounds, _args.padding);
-    }
   }
 
   async getMapBounds(_args: { id: string }): Promise<LatLngBounds> {
@@ -493,7 +418,7 @@ export class CapacitorGoogleMapsWeb extends WebPlugin implements CapacitorGoogle
       config.mapId = `capacitor_map_${this.currMapId++}`;
     }
 
-    this.maps[_args.id] = {
+    const mapInstance = {
       map: new window.google.maps.Map(_args.element, config),
       element: _args.element,
       markers: {},
@@ -502,7 +427,82 @@ export class CapacitorGoogleMapsWeb extends WebPlugin implements CapacitorGoogle
       circles: {},
       polylines: {},
     };
+    this.applyConfig(mapInstance, config);
+    this.maps[_args.id] = mapInstance;
     this.setMapListeners(_args.id);
+  }
+
+  async update(_args: UpdateMapArgs): Promise<void> {
+    const mapInstance = this.maps[_args.id];
+    mapInstance.map.setOptions(_args.config);
+
+    this.applyConfig(mapInstance, _args.config);
+  }
+
+  private applyConfig(mapInstance: MapInstance, config: GoogleMapConfig): void {
+    if (config.isMyLocationEnabled) {
+      this.enableMyLocation(mapInstance);
+    }
+
+    if (config.isTrafficLayerEnabled !== undefined) {
+      this.setTrafficLayer(mapInstance, config.isTrafficLayerEnabled);
+    }
+
+    if (config.mapTypeId !== undefined) {
+      this.setMapTypeId(mapInstance, config.mapTypeId as string);
+    }
+
+    if (config.padding !== undefined) {
+      this.setPadding(mapInstance, config.padding);
+    }
+  }
+
+  private enableMyLocation(mapInstance: MapInstance): void {
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(
+        (position: GeolocationPosition) => {
+          const pos = {
+            lat: position.coords.latitude,
+            lng: position.coords.longitude,
+          };
+
+          mapInstance.map.setCenter(pos);
+
+          this.notifyListeners('onMyLocationButtonClick', {});
+
+          this.notifyListeners('onMyLocationClick', {});
+        },
+        () => {
+          throw new Error('Geolocation not supported on web browser.');
+        },
+      );
+    } else {
+      throw new Error('Geolocation not supported on web browser.');
+    }
+  }
+
+  private setTrafficLayer(mapInstance: MapInstance, enabled: boolean): void {
+    const trafficLayer = mapInstance.trafficLayer ?? new google.maps.TrafficLayer();
+
+    if (enabled) {
+      trafficLayer.setMap(mapInstance.map);
+      mapInstance.trafficLayer = trafficLayer;
+    } else if (mapInstance.trafficLayer) {
+      trafficLayer.setMap(null);
+      mapInstance.trafficLayer = undefined;
+    }
+  }
+
+  private setMapTypeId(mapInstance: MapInstance, typeId: string): void {
+    mapInstance.map.setMapTypeId(typeId);
+  }
+
+  private setPadding(mapInstance: MapInstance, padding: MapPadding): void {
+    const bounds = mapInstance.map.getBounds();
+
+    if (bounds !== undefined) {
+      mapInstance.map.fitBounds(bounds, padding);
+    }
   }
 
   async destroy(_args: DestroyMapArgs): Promise<void> {


### PR DESCRIPTION
This refactorings simplify the map options handling and therefore remove many methods, that can now be set in the instantiation of the map but also be updated with a new method.

I also fixed an issue with the padding values in Android, that were used as DP value. I used the getScaledPixels to convert the DP values to screen PX. Now its working fine.

Closes https://github.com/ionic-team/capacitor-google-maps/issues/25