### PR TITLE
fix: add `getMapsBounds()` to `GoogleMapInterface` and `README.md`

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -305,6 +305,7 @@ export default MyMap;
 * [`enableAccessibilityElements(...)`](#enableaccessibilityelements)
 * [`enableCurrentLocation(...)`](#enablecurrentlocation)
 * [`setPadding(...)`](#setpadding)
+* [`getMapBounds()`](#getmapbounds)
 * [`fitBounds(...)`](#fitbounds)
 * [`setOnBoundsChangedListener(...)`](#setonboundschangedlistener)
 * [`setOnCameraIdleListener(...)`](#setoncameraidlelistener)
@@ -636,6 +637,19 @@ setPadding(padding: MapPadding) => Promise<void>
 | Param         | Type                                              |
 | ------------- | ------------------------------------------------- |
 | **`padding`** | <code><a href="#mappadding">MapPadding</a></code> |
+
+--------------------
+
+
+### getMapBounds()
+
+```typescript
+getMapBounds() => Promise<LatLngBounds>
+```
+
+Get the map's current viewport latitude and longitude bounds.
+
+**Returns:** <code>Promise&lt;LatLngBounds&gt;</code>
 
 --------------------
 

--- a/plugin/src/map.ts
+++ b/plugin/src/map.ts
@@ -58,6 +58,12 @@ export interface GoogleMapInterface {
   enableCurrentLocation(enabled: boolean): Promise<void>;
   setPadding(padding: MapPadding): Promise<void>;
   /**
+   * Get the map's current viewport latitude and longitude bounds.
+   *
+   * @returns {LatLngBounds}
+   */
+  getMapBounds(): Promise<LatLngBounds>;
+  /**
    * Sets the map viewport to contain the given bounds.
    * @param bounds The bounds to fit in the viewport.
    * @param padding Optional padding to apply in pixels. The bounds will be fit in the part of the map that remains after padding is removed.


### PR DESCRIPTION
- Adds `getMapsBounds()` to `GoogleMapInterface`
- Adds `getMapsBounds()` to `README.md` as a result of running `npm run docgen`