### PR TITLE
feat: update to show installation requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Version 6 of this plugin has a minimum deployment target of iOS 14.0. You will n
 platform :ios, '14.0'
 ```
 
-Additionally, you will need to open your project in XCode and in the `Build Settings` tab select `Targets` > `App` (or the name of your target) and set the `iOS Deployment Target` to `iOS 14` or higher.
+Additionally, you will need to open your project in XCode and in the `Build Settings` tab for your `Project` and for each `Target` set the `iOS Deployment Target` to `iOS 14` or higher.
 
 ### Typescript Configuration
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Version 6 of this plugin has a minimum deployment target of iOS 14.0. You will n
 platform :ios, '14.0'
 ```
 
+Additionally, you will need to open your project in XCode and set the `iOS Deployment Target` to `iOS 14.0` or higher in the `Build Settings` tab.
+
 ### Typescript Configuration
 
 Your project will also need have `skipLibCheck` set to `true` in `tsconfig.json`.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,18 @@ The Google Maps SDK supports the use of showing the users current location via `
 
 Read about [Configuring `Info.plist`](https://capacitorjs.com/docs/ios/configuration#configuring-infoplist) in the [iOS Guide](https://capacitorjs.com/docs/ios) for more information on setting iOS permissions in Xcode.
 
+### Minimum Deployment Target
+
+Version 6 of this plugin has a minimum deployment target of iOS 14.0. You will need to edit `ios/App/Podfile` and change the following line from 13.0 to 14.0:
+```
+platform :ios, '14.0'
+```
+
+### Typescript Configuration
+
+Your project will also need have `skipLibCheck` set to `true` in `tsconfig.json`.
+
+### Migrating from older versions
 > The main Google Maps SDK now supports running on simulators on Apple Silicon Macs, but make sure you have the latest version of [Google-Maps-iOS-Utils](https://github.com/googlemaps/google-maps-ios-utils) installed.
 
 If you added the previous workaround for getting the unreleased version, you can delete it now by removing this line from `ios/App/Podfile`:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Version 6 of this plugin has a minimum deployment target of iOS 14.0. You will n
 platform :ios, '14.0'
 ```
 
-Additionally, you will need to open your project in XCode and set the `iOS Deployment Target` to `iOS 14.0` or higher in the `Build Settings` tab.
+Additionally, you will need to open your project in XCode and in the `Build Settings` tab select `Targets` > `App` (or the name of your target) and set the `iOS Deployment Target` to `iOS 14` or higher.
 
 ### Typescript Configuration
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Version 6 of this plugin has a minimum deployment target of iOS 14.0. You will n
 platform :ios, '14.0'
 ```
 
-Additionally, you will need to open your project in XCode and in the `Build Settings` tab for your `Project` and for each `Target` set the `iOS Deployment Target` to `iOS 14` or higher.
+Additionally, you will need to open your project in XCode and in the `Build Settings` tab for your `Project` and for each `Target` set the `iOS Deployment Target` to `iOS 14.0` or higher.
 
 ### Typescript Configuration
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -21,6 +21,20 @@ The Google Maps SDK supports the use of showing the users current location via `
 
 Read about [Configuring `Info.plist`](https://capacitorjs.com/docs/ios/configuration#configuring-infoplist) in the [iOS Guide](https://capacitorjs.com/docs/ios) for more information on setting iOS permissions in Xcode.
 
+### Minimum Deployment Target
+
+Version 6 of this plugin has a minimum deployment target of iOS 14.0. You will need to edit `ios/App/Podfile` and change the following line from 13.0 to 14.0:
+```
+platform :ios, '14.0'
+```
+
+Additionally, you will need to open your project in XCode and set the `iOS Deployment Target` to `iOS 14.0` or higher in the `Build Settings` tab.
+
+### Typescript Configuration
+
+Your project will also need have `skipLibCheck` set to `true` in `tsconfig.json`.
+
+### Migrating from older versions
 > The main Google Maps SDK now supports running on simulators on Apple Silicon Macs, but make sure you have the latest version of [Google-Maps-iOS-Utils](https://github.com/googlemaps/google-maps-ios-utils) installed.
 
 If you added the previous workaround for getting the unreleased version, you can delete it now by removing this line from `ios/App/Podfile`:

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -28,7 +28,7 @@ Version 6 of this plugin has a minimum deployment target of iOS 14.0. You will n
 platform :ios, '14.0'
 ```
 
-Additionally, you will need to open your project in XCode and in the `Build Settings` tab select `Targets` > `App` (or the name of your target) and set the `iOS Deployment Target` to `iOS 14` or higher.
+Additionally, you will need to open your project in XCode and in the `Build Settings` tab for your `Project` and for each `Target` set the `iOS Deployment Target` to `iOS 14` or higher.
 
 ### Typescript Configuration
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -28,7 +28,7 @@ Version 6 of this plugin has a minimum deployment target of iOS 14.0. You will n
 platform :ios, '14.0'
 ```
 
-Additionally, you will need to open your project in XCode and set the `iOS Deployment Target` to `iOS 14.0` or higher in the `Build Settings` tab.
+Additionally, you will need to open your project in XCode and in the `Build Settings` tab select `Targets` > `App` (or the name of your target) and set the `iOS Deployment Target` to `iOS 14` or higher.
 
 ### Typescript Configuration
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -28,7 +28,7 @@ Version 6 of this plugin has a minimum deployment target of iOS 14.0. You will n
 platform :ios, '14.0'
 ```
 
-Additionally, you will need to open your project in XCode and in the `Build Settings` tab for your `Project` and for each `Target` set the `iOS Deployment Target` to `iOS 14` or higher.
+Additionally, you will need to open your project in XCode and in the `Build Settings` tab for your `Project` and for each `Target` set the `iOS Deployment Target` to `iOS 14.0` or higher.
 
 ### Typescript Configuration
 


### PR DESCRIPTION
This adds the missing requirements for minimum iOS deployment target of 14.0 and the skipLibCheck property in TSConfig.