### PR TITLE
Replace events.removeFirst with events.removeAt(0)

### DIFF
--- a/plugin/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMapsPlugin.kt
+++ b/plugin/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMapsPlugin.kt
@@ -888,7 +888,7 @@ class CapacitorGoogleMapsPlugin : Plugin(), OnMapsSdkInitializedCallback {
                     } else {
                         this.bridge.webView.onTouchEvent(event)
                     }
-                    events.removeFirst()
+                    events.removeAt(0)
                 }
             }
 


### PR DESCRIPTION
Due to issues outline [here](https://youtrack.jetbrains.com/issue/KT-71375/Prevent-Kotlins-removeFirst-and-removeLast-from-causing-crashes-on-Android-14-and-below-after-upgrading-to-Android-API-Level-35), ```list.removeFirst()``` produces a runtime error for apps targeting Android 35. Until this issue is resolved, ```list.removeAt(0)``` must be used