### PR TITLE
feat: add support for managing tile overlays

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,8 @@ export default MyMap;
 * [`disableTouch()`](#disabletouch)
 * [`enableClustering(...)`](#enableclustering)
 * [`disableClustering()`](#disableclustering)
+* [`addTileOverlay(...)`](#addtileoverlay)
+* [`removeTileOverlay(...)`](#removetileoverlay)
 * [`addMarker(...)`](#addmarker)
 * [`addMarkers(...)`](#addmarkers)
 * [`removeMarker(...)`](#removemarker)
@@ -319,6 +321,7 @@ export default MyMap;
 * [`enableAccessibilityElements(...)`](#enableaccessibilityelements)
 * [`enableCurrentLocation(...)`](#enablecurrentlocation)
 * [`setPadding(...)`](#setpadding)
+* [`getMapBounds()`](#getmapbounds)
 * [`fitBounds(...)`](#fitbounds)
 * [`setOnBoundsChangedListener(...)`](#setonboundschangedlistener)
 * [`setOnCameraIdleListener(...)`](#setoncameraidlelistener)
@@ -397,6 +400,34 @@ enableClustering(minClusterSize?: number | undefined) => Promise<void>
 ```typescript
 disableClustering() => Promise<void>
 ```
+
+--------------------
+
+
+### addTileOverlay(...)
+
+```typescript
+addTileOverlay(tileOverlay: TileOverlay) => Promise<{ id: string; }>
+```
+
+| Param             | Type                                                |
+| ----------------- | --------------------------------------------------- |
+| **`tileOverlay`** | <code><a href="#tileoverlay">TileOverlay</a></code> |
+
+**Returns:** <code>Promise&lt;{ id: string; }&gt;</code>
+
+--------------------
+
+
+### removeTileOverlay(...)
+
+```typescript
+removeTileOverlay(id: string) => Promise<void>
+```
+
+| Param    | Type                |
+| -------- | ------------------- |
+| **`id`** | <code>string</code> |
 
 --------------------
 
@@ -650,6 +681,19 @@ setPadding(padding: MapPadding) => Promise<void>
 | Param         | Type                                              |
 | ------------- | ------------------------------------------------- |
 | **`padding`** | <code><a href="#mappadding">MapPadding</a></code> |
+
+--------------------
+
+
+### getMapBounds()
+
+```typescript
+getMapBounds() => Promise<LatLngBounds>
+```
+
+Get the map's current viewport latitude and longitude bounds.
+
+**Returns:** <code>Promise&lt;LatLngBounds&gt;</code>
 
 --------------------
 
@@ -935,6 +979,18 @@ An interface representing a pair of latitude and longitude coordinates.
 | **`mapId`** | <code>string</code> |
 
 
+#### TileOverlay
+
+A tile overlay is an image placed on top of your map at a specific zoom level. Available on iOS, Android and Web
+
+| Prop          | Type                                                        | Description                                                                                                            | Default                |
+| ------------- | ----------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | ---------------------- |
+| **`getTile`** | <code><a href="#gettilecallback">GetTileCallback</a></code> | A callback function that returns the tile url. Available on iOS, Android and Web                                       |                        |
+| **`opacity`** | <code>number</code>                                         | The opacity of the tile overlay, between 0 (completely transparent) and 1 inclusive. Available on iOS, Android and Web | <code>undefined</code> |
+| **`visible`** | <code>boolean</code>                                        | Controls whether this tile overlay should be visible. Available only on Android                                        | <code>undefined</code> |
+| **`zIndex`**  | <code>number</code>                                         | The zIndex of the tile overlay. Available on iOS and Android                                                           | <code>undefined</code> |
+
+
 #### Marker
 
 A marker is an icon placed at a particular point on the map's surface.
@@ -1156,6 +1212,11 @@ Controls for setting padding on the 'visible' region of the view.
 The callback function to be called when map events are emitted.
 
 <code>(data: T): void</code>
+
+
+#### GetTileCallback
+
+<code>(x: number, y: number, zoom: number): string</code>
 
 
 #### Position

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -300,6 +300,8 @@ export default MyMap;
 * [`disableTouch()`](#disabletouch)
 * [`enableClustering(...)`](#enableclustering)
 * [`disableClustering()`](#disableclustering)
+* [`addTileOverlay(...)`](#addtileoverlay)
+* [`removeTileOverlay(...)`](#removetileoverlay)
 * [`addMarker(...)`](#addmarker)
 * [`addMarkers(...)`](#addmarkers)
 * [`removeMarker(...)`](#removemarker)
@@ -398,6 +400,34 @@ enableClustering(minClusterSize?: number | undefined) => Promise<void>
 ```typescript
 disableClustering() => Promise<void>
 ```
+
+--------------------
+
+
+### addTileOverlay(...)
+
+```typescript
+addTileOverlay(tileOverlay: TileOverlay) => Promise<{ id: string; }>
+```
+
+| Param             | Type                                                |
+| ----------------- | --------------------------------------------------- |
+| **`tileOverlay`** | <code><a href="#tileoverlay">TileOverlay</a></code> |
+
+**Returns:** <code>Promise&lt;{ id: string; }&gt;</code>
+
+--------------------
+
+
+### removeTileOverlay(...)
+
+```typescript
+removeTileOverlay(id: string) => Promise<void>
+```
+
+| Param    | Type                |
+| -------- | ------------------- |
+| **`id`** | <code>string</code> |
 
 --------------------
 
@@ -949,6 +979,18 @@ An interface representing a pair of latitude and longitude coordinates.
 | **`mapId`** | <code>string</code> |
 
 
+#### TileOverlay
+
+A tile overlay is an image placed on top of your map at a specific zoom level. Available on iOS, Android and Web
+
+| Prop          | Type                                                        | Description                                                                                                            | Default                |
+| ------------- | ----------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | ---------------------- |
+| **`getTile`** | <code><a href="#gettilecallback">GetTileCallback</a></code> | A callback function that returns the tile url. Available on iOS, Android and Web                                       |                        |
+| **`opacity`** | <code>number</code>                                         | The opacity of the tile overlay, between 0 (completely transparent) and 1 inclusive. Available on iOS, Android and Web | <code>undefined</code> |
+| **`visible`** | <code>boolean</code>                                        | Controls whether this tile overlay should be visible. Available only on Android                                        | <code>undefined</code> |
+| **`zIndex`**  | <code>number</code>                                         | The zIndex of the tile overlay. Available on iOS and Android                                                           | <code>undefined</code> |
+
+
 #### Marker
 
 A marker is an icon placed at a particular point on the map's surface.
@@ -1170,6 +1212,11 @@ Controls for setting padding on the 'visible' region of the view.
 The callback function to be called when map events are emitted.
 
 <code>(data: T): void</code>
+
+
+#### GetTileCallback
+
+<code>(x: number, y: number, zoom: number): string</code>
 
 
 #### Position

--- a/plugin/android/settings.gradle
+++ b/plugin/android/settings.gradle
@@ -1,2 +1,2 @@
 include ':capacitor-android'
-project(':capacitor-android').projectDir = new File('../node_modules/@capacitor/android/capacitor')
+project(':capacitor-android').projectDir = new File('../../node_modules/@capacitor/android/capacitor')

--- a/plugin/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMap.kt
+++ b/plugin/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMap.kt
@@ -18,9 +18,14 @@ import com.google.maps.android.clustering.Cluster
 import com.google.maps.android.clustering.ClusterManager
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import java.io.InputStream
+import java.net.HttpURLConnection
 import java.net.URL
-
+import java.util.concurrent.TimeoutException
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
 
 class CapacitorGoogleMap(
         val id: String,
@@ -43,6 +48,7 @@ class CapacitorGoogleMap(
     private var mapView: MapView
     private var googleMap: GoogleMap? = null
     private val markers = HashMap<String, CapacitorGoogleMapMarker>()
+    private val tileOverlays = HashMap<String, CapacitorGoogleMapTileOverlay>()
     private val polygons = HashMap<String, CapacitorGoogleMapsPolygon>()
     private val circles = HashMap<String, CapacitorGoogleMapsCircle>()
     private val polylines = HashMap<String, CapacitorGoogleMapPolyline>()        
@@ -170,6 +176,73 @@ class CapacitorGoogleMap(
                     }
 
             job.join()
+        }
+    }
+
+    fun addTileOverlay(
+        tileOverlay: CapacitorGoogleMapTileOverlay,
+        getTile: (x: Int, y: Int, zoom: Int, callback: (String) -> Unit) -> Unit,
+        callback: (Result<String>) -> Unit
+    ) {
+        try {
+            googleMap ?: throw GoogleMapNotAvailable()
+
+            CoroutineScope(Dispatchers.Main).launch {
+                val tileProvider = object : UrlTileProvider(256, 256) {
+                    override fun getTileUrl(x: Int, y: Int, zoom: Int): URL? {
+                        suspend fun getTileSuspend(): String {
+                            return withTimeoutOrNull(5000L) {
+                                suspendCoroutine { continuation ->
+                                    getTile(x, y, zoom) { continuation.resume(it) }
+                                }
+                            } ?: throw TimeoutException("getTile $id timed out")
+                        }
+
+                        return try {
+                            runBlocking { URL(getTileSuspend()) }
+                        } catch (e: Exception) {
+                            null
+                        }
+                    }
+                }
+                var tileOverlayOptions = TileOverlayOptions().tileProvider(tileProvider)
+                if (tileOverlay.zIndex != null) {
+                    tileOverlayOptions.zIndex(tileOverlay.zIndex!!)
+                }
+                if (tileOverlay.visible != null) {
+                    tileOverlayOptions.visible(tileOverlay.visible!!)
+                }
+                if (tileOverlay.opacity != null) {
+                    tileOverlayOptions.transparency(tileOverlay.opacity!!)
+                }
+
+                val googleMapTileOverlay = googleMap?.addTileOverlay(tileOverlayOptions)
+
+                tileOverlay.googleMapTileOverlay = googleMapTileOverlay
+                tileOverlays[googleMapTileOverlay!!.id] = tileOverlay
+
+                callback(Result.success(googleMapTileOverlay.id))
+            }
+        } catch (e: GoogleMapsError) {
+            callback(Result.failure(e))
+        }
+    }
+
+    fun removeTileOverlay(id: String, callback: (error: GoogleMapsError?) -> Unit) {
+        try {
+            googleMap ?: throw GoogleMapNotAvailable()
+
+            val tileOverlay = tileOverlays[id]
+            tileOverlay ?: throw TileOverlayNotFoundError()
+
+            CoroutineScope(Dispatchers.Main).launch {
+                tileOverlay.googleMapTileOverlay?.remove()
+                tileOverlays.remove(id)
+
+                callback(null)
+            }
+        } catch (e: GoogleMapsError) {
+            callback(e)
         }
     }
 

--- a/plugin/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMapTileOverlay.kt
+++ b/plugin/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMapTileOverlay.kt
@@ -1,0 +1,28 @@
+package com.capacitorjs.plugins.googlemaps
+
+import com.google.android.gms.maps.model.TileOverlay
+import org.json.JSONObject
+
+class CapacitorGoogleMapTileOverlay(fromJSONObject: JSONObject) {
+    var getTileCallbackId: String
+    var opacity: Float? = null
+    var zIndex: Float? = null
+    var visible: Boolean? = null
+    var googleMapTileOverlay: TileOverlay? = null
+
+    init {
+        if (!fromJSONObject.has("getTileCallbackId")) {
+            throw InvalidArgumentsError("TileOverlay object is missing the required 'getTileCallbackId' property")
+        }
+        getTileCallbackId = fromJSONObject.getString("getTileCallbackId")
+        if (fromJSONObject.has("opacity")) {
+            opacity = fromJSONObject.optDouble("opacity").toFloat()
+        }
+        if (fromJSONObject.has("visible")) {
+            visible = fromJSONObject.optBoolean("visible")
+        }
+        if (fromJSONObject.has("zIndex")) {
+            zIndex = fromJSONObject.optLong("zIndex").toFloat()
+        }
+    }
+}

--- a/plugin/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMapsPlugin.kt
+++ b/plugin/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMapsPlugin.kt
@@ -210,6 +210,90 @@ class CapacitorGoogleMapsPlugin : Plugin(), OnMapsSdkInitializedCallback {
         }
     }
 
+    private val getTileCallbackRegistry = HashMap<String, (String) -> Unit>()
+
+    @PluginMethod
+    fun getTileCallbackResponse(call: PluginCall) {
+        try {
+            val callbackId = call.getString("callbackId")
+            callbackId ?: throw InvalidArgumentsError("callbackId is invalid or missing")
+
+            if (!getTileCallbackRegistry.containsKey(callbackId)) {
+                throw InvalidArgumentsError("callbackId does not match an existing callback in the registry")
+            }
+
+            val result = call.getString("result")
+            result ?: throw InvalidArgumentsError("result is invalid or missing")
+
+            getTileCallbackRegistry[callbackId]!!(result)
+
+            call.resolve()
+        } catch (e: Exception) {
+            handleError(call, e)
+        }
+    }
+
+    @PluginMethod
+    fun addTileOverlay(call: PluginCall) {
+        try {
+            val id = call.getString("id")
+            id ?: throw InvalidMapIdError()
+
+            val tileOverlayObj = call.getObject("tileOverlay", null)
+            tileOverlayObj ?: throw InvalidArgumentsError("tileOverlay object is missing")
+
+            val map = maps[id]
+            map ?: throw MapNotFoundError()
+
+            val tileOverlay = CapacitorGoogleMapTileOverlay(tileOverlayObj)
+            map.addTileOverlay(tileOverlay, { x, y, zoom, handler ->
+                getTileCallbackRegistry[tileOverlay.getTileCallbackId] = handler
+                val eventData = JSObject()
+                eventData.put("callbackId", tileOverlay.getTileCallbackId)
+                eventData.put("x", x)
+                eventData.put("y", y)
+                eventData.put("zoom", zoom)
+                notifyListeners("getTileCallback", eventData)
+            }) { result ->
+                val tileOverlayId = result.getOrThrow()
+
+                val res = JSObject()
+                res.put("id", tileOverlayId)
+                call.resolve(res)
+            }
+        } catch (e: GoogleMapsError) {
+            handleError(call, e)
+        } catch (e: Exception) {
+            handleError(call, e)
+        }
+    }
+
+    @PluginMethod
+    fun removeTileOverlay(call: PluginCall) {
+        try {
+            val id = call.getString("id")
+            id ?: throw InvalidMapIdError()
+
+            val tileOverlayId = call.getString("tileOverlayId")
+            tileOverlayId ?: throw InvalidArgumentsError("tileOverlayId is invalid or missing")
+
+            val map = maps[id]
+            map ?: throw MapNotFoundError()
+
+            map.removeTileOverlay(tileOverlayId) { err ->
+                if (err != null) {
+                    throw err
+                }
+
+                call.resolve()
+            }
+        } catch (e: GoogleMapsError) {
+            handleError(call, e)
+        } catch (e: Exception) {
+            handleError(call, e)
+        }
+    }
+
     @PluginMethod
     fun addMarker(call: PluginCall) {
         try {

--- a/plugin/android/src/main/java/com/capacitorjs/plugins/googlemaps/GoogleMapErrors.kt
+++ b/plugin/android/src/main/java/com/capacitorjs/plugins/googlemaps/GoogleMapErrors.kt
@@ -4,7 +4,7 @@ import org.json.JSONObject
 import kotlin.Exception
 
 enum class GoogleMapErrors {
-    UNHANDLED_ERROR, INVALID_MAP_ID, MAP_NOT_FOUND, MARKER_NOT_FOUND, INVALID_ARGUMENTS, PERMISSIONS_DENIED_LOCATION, GOOGLE_MAP_NOT_AVAILABLE, BOUNDS_NOT_FOUND
+    UNHANDLED_ERROR, INVALID_MAP_ID, MAP_NOT_FOUND, MARKER_NOT_FOUND, TILE_OVERLAY_NOT_FOUND, INVALID_ARGUMENTS, PERMISSIONS_DENIED_LOCATION, GOOGLE_MAP_NOT_AVAILABLE, BOUNDS_NOT_FOUND
 }
 
 class GoogleMapErrorObject(val code: Int, val message: String, val extra: HashMap<String,Any> = HashMap()) {
@@ -77,6 +77,12 @@ class MapNotFoundError(message: String? = ""): GoogleMapsError(message) {
 class MarkerNotFoundError(message: String? = ""): GoogleMapsError(message) {
     override fun getErrorCode(): Int {
         return GoogleMapErrors.MARKER_NOT_FOUND.ordinal
+    }
+}
+
+class TileOverlayNotFoundError(message: String? = ""): GoogleMapsError(message) {
+    override fun getErrorCode(): Int {
+        return GoogleMapErrors.TILE_OVERLAY_NOT_FOUND.ordinal
     }
 }
 

--- a/plugin/ios/Plugin.xcodeproj/project.pbxproj
+++ b/plugin/ios/Plugin.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		50ADFFA42020D75100D50D53 /* Capacitor.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 50ADFFA52020D75100D50D53 /* Capacitor.framework */; };
 		50ADFFA82020EE4F00D50D53 /* CapacitorGoogleMapsPlugin.m in Sources */ = {isa = PBXBuildFile; fileRef = 50ADFFA72020EE4F00D50D53 /* CapacitorGoogleMapsPlugin.m */; };
 		50E1A94820377CB70090CE1A /* CapacitorGoogleMapsPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E1A94720377CB70090CE1A /* CapacitorGoogleMapsPlugin.swift */; };
+		98A74CEF2D15A1D200037A0B /* TileOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98A74CEE2D15A1D100037A0B /* TileOverlay.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -59,6 +60,7 @@
 		5E23F77F099397094342571A /* Pods-Plugin.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Plugin.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Plugin/Pods-Plugin.debug.xcconfig"; sourceTree = "<group>"; };
 		91781294A431A2A7CC6EB714 /* Pods-Plugin.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Plugin.release.xcconfig"; path = "Pods/Target Support Files/Pods-Plugin/Pods-Plugin.release.xcconfig"; sourceTree = "<group>"; };
 		96ED1B6440D6672E406C8D19 /* Pods-PluginTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PluginTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-PluginTests/Pods-PluginTests.debug.xcconfig"; sourceTree = "<group>"; };
+		98A74CEE2D15A1D100037A0B /* TileOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TileOverlay.swift; sourceTree = "<group>"; };
 		F65BB2953ECE002E1EF3E424 /* Pods-PluginTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PluginTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-PluginTests/Pods-PluginTests.release.xcconfig"; sourceTree = "<group>"; };
 		F6753A823D3815DB436415E3 /* Pods_PluginTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PluginTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -108,6 +110,7 @@
 		50ADFF8A201F53D600D50D53 /* Plugin */ = {
 			isa = PBXGroup;
 			children = (
+				98A74CEE2D15A1D100037A0B /* TileOverlay.swift */,
 				50E1A94720377CB70090CE1A /* CapacitorGoogleMapsPlugin.swift */,
 				02C6EDF12798803E00D51BF6 /* Map.swift */,
 				50ADFF8B201F53D600D50D53 /* CapacitorGoogleMapsPlugin.h */,
@@ -374,6 +377,7 @@
 				0238AED727C931A40012930B /* GoogleMapCameraConfig.swift in Sources */,
 				0238AED927C945840012930B /* GoogleMapPadding.swift in Sources */,
 				02404C8F279F43E900CEF8C8 /* GoogleMapConfig.swift in Sources */,
+				98A74CEF2D15A1D200037A0B /* TileOverlay.swift in Sources */,
 				02B55EAE29EA0CF000493664 /* Circle.swift in Sources */,
 				02B55EAC29E9AAAA00493664 /* Polygon.swift in Sources */,
 				02C6EDF22798803E00D51BF6 /* Map.swift in Sources */,

--- a/plugin/ios/Plugin/CapacitorGoogleMapsPlugin.m
+++ b/plugin/ios/Plugin/CapacitorGoogleMapsPlugin.m
@@ -7,6 +7,9 @@ CAP_PLUGIN(CapacitorGoogleMapsPlugin, "CapacitorGoogleMaps",
    CAP_PLUGIN_METHOD(create, CAPPluginReturnPromise);
    CAP_PLUGIN_METHOD(enableTouch, CAPPluginReturnPromise);
    CAP_PLUGIN_METHOD(disableTouch, CAPPluginReturnPromise);
+   CAP_PLUGIN_METHOD(getTileCallbackResponse, CAPPluginReturnPromise);
+   CAP_PLUGIN_METHOD(addTileOverlay, CAPPluginReturnPromise);
+   CAP_PLUGIN_METHOD(removeTileOverlay, CAPPluginReturnPromise);
    CAP_PLUGIN_METHOD(addMarker, CAPPluginReturnPromise);
    CAP_PLUGIN_METHOD(addMarkers, CAPPluginReturnPromise);
    CAP_PLUGIN_METHOD(addPolygons, CAPPluginReturnPromise);

--- a/plugin/ios/Plugin/CapacitorGoogleMapsPlugin.swift
+++ b/plugin/ios/Plugin/CapacitorGoogleMapsPlugin.swift
@@ -68,8 +68,7 @@ public class CapacitorGoogleMapsPlugin: CAPPlugin, GMSMapViewDelegate {
     private var maps = [String: Map]()
     private var isInitialized = false
     private var locationManager = CLLocationManager()
-    
-    
+
     func checkLocationPermission() -> String {
         let locationState: String
 
@@ -177,6 +176,88 @@ public class CapacitorGoogleMapsPlugin: CAPPlugin, GMSMapViewDelegate {
             }
 
             map.disableTouch()
+
+            call.resolve()
+        } catch {
+            handleError(call, error: error)
+        }
+    }
+
+    private var getTileCallbackRegistry: [String: (String) -> Void] = [:]
+
+    @objc func getTileCallbackResponse(_ call: CAPPluginCall) {
+        do {
+            guard let callbackId = call.getString("callbackId") else {
+                throw GoogleMapErrors.invalidArguments("callbackId is missing")
+            }
+
+            guard getTileCallbackRegistry.keys.contains(where: { $0 == callbackId }) else {
+                throw GoogleMapErrors.invalidArguments("callbackId does not match an existing callback in the registry")
+            }
+
+            guard let result = call.getString("result") else {
+                throw GoogleMapErrors.invalidArguments("result is missing")
+            }
+
+            getTileCallbackRegistry[callbackId]?(result)
+
+            call.resolve()
+        } catch {
+            handleError(call, error: error)
+        }
+    }
+
+    @objc func addTileOverlay(_ call: CAPPluginCall) {
+        do {
+            guard let id = call.getString("id") else {
+                throw GoogleMapErrors.invalidMapId
+            }
+
+            guard let tileOverlayObj = call.getObject("tileOverlay") else {
+                throw GoogleMapErrors.invalidArguments("tileOverlay object is missing")
+            }
+
+            let tileOverlay = try TileOverlay(fromJSObject: tileOverlayObj)
+
+            guard let map = self.maps[id] else {
+                throw GoogleMapErrors.mapNotFound
+            }
+
+            let tileOverlayId = try map.addTileOverlay(tileOverlay: tileOverlay) { [weak self] x, y, zoom, handler in
+                guard let self else { return }
+
+                getTileCallbackRegistry[tileOverlay.getTileCallbackId] = handler
+                notifyListeners("getTileCallback", data: [
+                    "callbackId": tileOverlay.getTileCallbackId,
+                    "x": x, "y": y, "zoom": zoom
+                ])
+            }
+
+            call.resolve(["id": String(tileOverlayId)])
+        } catch {
+            handleError(call, error: error)
+        }
+    }
+
+    @objc func removeTileOverlay(_ call: CAPPluginCall) {
+        do {
+            guard let id = call.getString("id") else {
+                throw GoogleMapErrors.invalidMapId
+            }
+
+            guard let tileOverlayIdString = call.getString("tileOverlayId") else {
+                throw GoogleMapErrors.invalidArguments("tileOverlayId is invalid or missing")
+            }
+
+            guard let tileOverlayId = Int(tileOverlayIdString) else {
+                throw GoogleMapErrors.invalidArguments("tileOverlayId is invalid or missing")
+            }
+
+            guard let map = self.maps[id] else {
+                throw GoogleMapErrors.mapNotFound
+            }
+
+            try map.removeTileOverlay(id: tileOverlayId)
 
             call.resolve()
         } catch {
@@ -684,7 +765,7 @@ public class CapacitorGoogleMapsPlugin: CAPPlugin, GMSMapViewDelegate {
             guard let enabled = call.getBool("enabled") else {
                 throw GoogleMapErrors.invalidArguments("enabled is missing")
             }
-            
+
             let locationStatus = checkLocationPermission()
 
             if enabled &&  !(locationStatus == "granted" || locationStatus == "prompt") {

--- a/plugin/ios/Plugin/GoogleMapErrors.swift
+++ b/plugin/ios/Plugin/GoogleMapErrors.swift
@@ -4,6 +4,7 @@ public enum GoogleMapErrors: Error {
     case invalidMapId
     case mapNotFound
     case markerNotFound
+    case tileOverlayNotFound
     case invalidArguments(_ description: String)
     case invalidAPIKey
     case permissionsDeniedLocation

--- a/plugin/ios/Plugin/Map.swift
+++ b/plugin/ios/Plugin/Map.swift
@@ -75,6 +75,7 @@ public class Map {
     var mapViewController: GMViewController
     var targetViewController: UIView?
     var markers = [Int: GMSMarker]()
+    var tileOverlays = [Int: GMSURLTileLayer]()
     var polygons = [Int: GMSPolygon]()
     var circles = [Int: GMSCircle]()
     var polylines = [Int: GMSPolyline]()
@@ -209,6 +210,51 @@ public class Map {
             if let target = self.targetViewController, let itemIndex = WKWebView.disabledTargets.firstIndex(of: target) {
                 WKWebView.disabledTargets.remove(at: itemIndex)
             }
+        }
+    }
+
+    func addTileOverlay(
+        tileOverlay: TileOverlay,
+        getTile: @escaping (Int, Int, Int, @escaping (String) -> Void) -> Void
+    ) throws -> Int {
+        var tileOverlayHash = 0
+
+        DispatchQueue.main.async {
+            let urlConstructor: GMSTileURLConstructor = { x, y, zoom in
+                let semaphore = DispatchSemaphore(value: 0)
+                var resultURL: URL?
+
+                getTile(Int(x), Int(y), Int(zoom)) { result in
+                    resultURL = URL(string: result)
+                    semaphore.signal()
+                }
+
+                _ = semaphore.wait(timeout: .now() + 5)
+
+                return resultURL
+            }
+            let layer = GMSURLTileLayer(urlConstructor: urlConstructor)
+            layer.opacity = tileOverlay.opacity ?? 1
+            layer.zIndex = tileOverlay.zIndex
+            layer.map = self.mapViewController.GMapView
+
+            self.tileOverlays[layer.hash.hashValue] = layer
+
+            tileOverlayHash = layer.hash.hashValue
+        }
+
+        return tileOverlayHash
+    }
+
+    func removeTileOverlay(id: Int) throws {
+        if let tileOverlay = self.tileOverlays[id] {
+            DispatchQueue.main.async {
+                tileOverlay.map = nil
+                self.tileOverlays.removeValue(forKey: id)
+
+            }
+        } else {
+            throw GoogleMapErrors.tileOverlayNotFound
         }
     }
 

--- a/plugin/ios/Plugin/TileOverlay.swift
+++ b/plugin/ios/Plugin/TileOverlay.swift
@@ -1,0 +1,18 @@
+import Capacitor
+
+public struct TileOverlay {
+    let getTileCallbackId: String
+    let opacity: Float?
+    let visible: Bool?
+    let zIndex: Int32
+
+    init(fromJSObject: JSObject) throws {
+        guard let getTileCallbackId = fromJSObject["getTileCallbackId"] as? String else {
+            throw GoogleMapErrors.invalidArguments("TileOverlay object is missing the required 'getTileCallbackId' property")
+        }
+        self.getTileCallbackId = getTileCallbackId
+        self.opacity = fromJSObject["opacity"] as? Float
+        self.visible = fromJSObject["isFlat"] as? Bool
+        self.zIndex = Int32((fromJSObject["zIndex"] as? Int) ?? 0)
+    }
+}

--- a/plugin/src/definitions.ts
+++ b/plugin/src/definitions.ts
@@ -295,6 +295,54 @@ export interface MapPadding {
   bottom: number;
 }
 
+export type GetTileCallback = (x: number, y: number, zoom: number) => string;
+
+/**
+ * A tile overlay is an image placed on top of your map at a specific zoom level. Available on iOS, Android and Web
+ */
+export interface TileOverlay {
+  /**
+   * A callback function that returns the tile url. Available on iOS, Android and Web
+   *
+   * @type {GetTileCallback}
+   */
+  getTile: GetTileCallback;
+
+  /**
+   * The opacity of the tile overlay, between 0 (completely transparent) and 1 inclusive. Available on iOS, Android and Web
+   *
+   * @type {number | undefined}
+   * @default undefined
+   */
+  opacity?: number;
+
+  /**
+   * Controls whether this tile overlay should be visible. Available only on Android
+   *
+   * @type {boolean | undefined}
+   * @default undefined
+   */
+  visible?: boolean;
+
+  /**
+   * The zIndex of the tile overlay. Available on iOS and Android
+   *
+   * @type {number | undefined}
+   * @default undefined
+   */
+  zIndex?: number;
+}
+
+/**
+ * @ignore
+ */
+export interface NativeTileOverlay {
+  getTileCallbackId: string;
+  opacity?: number;
+  visible?: boolean;
+  zIndex?: number;
+}
+
 /**
  * A marker is an icon placed at a particular point on the map's surface.
  */

--- a/plugin/src/implementation.ts
+++ b/plugin/src/implementation.ts
@@ -1,17 +1,20 @@
 import type { Plugin } from '@capacitor/core';
-import { registerPlugin } from '@capacitor/core';
+import { Capacitor, registerPlugin } from '@capacitor/core';
 
 import type {
   CameraConfig,
   Circle,
+  GetTileCallback,
   GoogleMapConfig,
   LatLng,
   LatLngBounds,
   MapPadding,
   MapType,
   Marker,
+  NativeTileOverlay,
   Polygon,
   Polyline,
+  TileOverlay,
 } from './definitions';
 
 /**
@@ -117,6 +120,26 @@ export interface IndoorMapArgs {
   enabled: boolean;
 }
 
+export interface GetTileCallbackResponse {
+  callbackId: string;
+  result: string;
+}
+
+export interface RemoveTileOverlayArgs {
+  id: string;
+  tileOverlayId: string;
+}
+
+export interface AddTileOverlayArgs {
+  id: string;
+  tileOverlay: TileOverlay;
+}
+
+export interface _AddTileOverlayArgs {
+  id: string;
+  tileOverlay: TileOverlay | NativeTileOverlay;
+}
+
 export interface TrafficLayerArgs {
   id: string;
   enabled: boolean;
@@ -173,6 +196,9 @@ export interface CapacitorGoogleMapsPlugin extends Plugin {
   create(options: CreateMapArgs): Promise<void>;
   enableTouch(args: { id: string }): Promise<void>;
   disableTouch(args: { id: string }): Promise<void>;
+  getTileCallbackResponse(args: GetTileCallbackResponse): Promise<void>;
+  addTileOverlay(args: _AddTileOverlayArgs): Promise<{ id: string }>;
+  removeTileOverlay(args: RemoveTileOverlayArgs): Promise<void>;
   addMarker(args: AddMarkerArgs): Promise<{ id: string }>;
   addMarkers(args: AddMarkersArgs): Promise<{ ids: string[] }>;
   removeMarker(args: RemoveMarkerArgs): Promise<void>;
@@ -219,4 +245,42 @@ CapacitorGoogleMaps.addListener('isMapInFocus', (data) => {
   CapacitorGoogleMaps.dispatchMapEvent({ id: data.mapId, focus: mapInFocus });
 });
 
-export { CapacitorGoogleMaps };
+const getTileCallbackRegistry: Record<string, GetTileCallback> = {};
+
+CapacitorGoogleMaps.addListener(
+  'getTileCallback',
+  (data: { callbackId: string; x: number; y: number; zoom: number }) => {
+    const { callbackId, x, y, zoom } = data;
+
+    if (getTileCallbackRegistry[callbackId]) {
+      const result = getTileCallbackRegistry[callbackId](x, y, zoom);
+      CapacitorGoogleMaps.getTileCallbackResponse({ callbackId, result }).catch((error) =>
+        console.error(`Failed to send getTile callback response: ${error}`)
+      );
+    } else {
+      console.error(`Callback with id ${callbackId} does not exist in the registry`);
+    }
+  }
+);
+
+const addTileOverlay = async (args: AddTileOverlayArgs): Promise<{ id: string }> => {
+  const callbackId = `callback-${Date.now()}-${Math.random()}`;
+  getTileCallbackRegistry[callbackId] = args.tileOverlay.getTile;
+
+  const nativePlatform = Capacitor.getPlatform() === 'android' || Capacitor.getPlatform() === 'ios';
+  if (nativePlatform) {
+    const { tileOverlay, ...argsRest } = args;
+    const tileOverlayRest = Object.fromEntries(Object.entries(tileOverlay).filter(([key]) => key !== 'getTile'));
+    return await CapacitorGoogleMaps.addTileOverlay({
+      ...argsRest,
+      tileOverlay: {
+        ...tileOverlayRest,
+        getTileCallbackId: callbackId,
+      },
+    });
+  } else {
+    return await CapacitorGoogleMaps.addTileOverlay(args);
+  }
+};
+
+export { CapacitorGoogleMaps, addTileOverlay };

--- a/plugin/src/map.ts
+++ b/plugin/src/map.ts
@@ -19,10 +19,11 @@ import type {
   CircleClickCallbackData,
   Polyline,
   PolylineCallbackData,
+  TileOverlay,
 } from './definitions';
 import { LatLngBounds, MapType } from './definitions';
 import type { CreateMapArgs } from './implementation';
-import { CapacitorGoogleMaps } from './implementation';
+import { addTileOverlay, CapacitorGoogleMaps } from './implementation';
 
 export interface GoogleMapInterface {
   create(options: CreateMapArgs, callback?: MapListenerCallback<MapReadyCallbackData>): Promise<GoogleMap>;
@@ -35,6 +36,8 @@ export interface GoogleMapInterface {
     minClusterSize?: number
   ): Promise<void>;
   disableClustering(): Promise<void>;
+  addTileOverlay(tileOverlay: TileOverlay): Promise<{ id: string }>;
+  removeTileOverlay(id: string): Promise<void>;
   addMarker(marker: Marker): Promise<string>;
   addMarkers(markers: Marker[]): Promise<string[]>;
   removeMarker(id: string): Promise<void>;
@@ -330,6 +333,34 @@ export class GoogleMap {
   async disableClustering(): Promise<void> {
     return CapacitorGoogleMaps.disableClustering({
       id: this.id,
+    });
+  }
+
+  /**
+   * Adds a tile overlay to the map
+   *
+   * @param tileOverlay
+   * @returns created tile overlay id
+   */
+  async addTileOverlay(tileOverlay: TileOverlay): Promise<string> {
+    const res = await addTileOverlay({
+      id: this.id,
+      tileOverlay,
+    });
+
+    return res.id;
+  }
+
+  /**
+   * Removes a tile overlay from the map
+   *
+   * @param id of the tile overlay to remove from the map
+   * @returns void
+   */
+  async removeTileOverlay(id: string): Promise<void> {
+    return CapacitorGoogleMaps.removeTileOverlay({
+      id: this.id,
+      tileOverlayId: id,
     });
   }
 

--- a/plugin/src/web.ts
+++ b/plugin/src/web.ts
@@ -2,9 +2,10 @@ import { WebPlugin } from '@capacitor/core';
 import type { Cluster, onClusterClickHandler } from '@googlemaps/markerclusterer';
 import { MarkerClusterer, SuperClusterAlgorithm } from '@googlemaps/markerclusterer';
 
-import type { Marker } from './definitions';
+import type { Marker, TileOverlay } from './definitions';
 import { MapType, LatLngBounds } from './definitions';
 import type {
+  _AddTileOverlayArgs,
   AddMarkerArgs,
   CameraArgs,
   AddMarkersArgs,
@@ -27,6 +28,8 @@ import type {
   RemoveCirclesArgs,
   AddPolylinesArgs,
   RemovePolylinesArgs,
+  GetTileCallbackResponse,
+  RemoveTileOverlayArgs,
 } from './implementation';
 
 export class CapacitorGoogleMapsWeb extends WebPlugin implements CapacitorGoogleMapsPlugin {
@@ -37,6 +40,9 @@ export class CapacitorGoogleMapsWeb extends WebPlugin implements CapacitorGoogle
       map: google.maps.Map;
       markers: {
         [id: string]: google.maps.Marker;
+      };
+      tileOverlays: {
+        [id: string]: google.maps.ImageMapType;
       };
       polygons: {
         [id: string]: google.maps.Polygon;
@@ -52,6 +58,7 @@ export class CapacitorGoogleMapsWeb extends WebPlugin implements CapacitorGoogle
     };
   } = {};
   private currMarkerId = 0;
+  private currTileOverlayId = 0;
   private currPolygonId = 0;
   private currCircleId = 0;
   private currPolylineId = 0;
@@ -246,6 +253,47 @@ export class CapacitorGoogleMapsWeb extends WebPlugin implements CapacitorGoogle
     map.fitBounds(bounds, _args.padding);
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
+  async getTileCallbackResponse(_args: GetTileCallbackResponse): Promise<void> {}
+
+  async addTileOverlay(_args: _AddTileOverlayArgs): Promise<{ id: string }> {
+    const tileOverlay = _args.tileOverlay as TileOverlay;
+
+    if (tileOverlay.getTile === undefined) {
+      throw new Error('getTile is required');
+    }
+
+    const map = this.maps[_args.id].map;
+
+    const id = '' + this.currTileOverlayId;
+
+    const customMapOverlay = new google.maps.ImageMapType({
+      getTileUrl: function (coord, zoom) {
+        return tileOverlay.getTile(coord.x, coord.y, zoom);
+      },
+      tileSize: new google.maps.Size(256, 256),
+      opacity: tileOverlay.opacity,
+    });
+
+    this.maps[_args.id].tileOverlays[id] = customMapOverlay;
+
+    map.overlayMapTypes.push(customMapOverlay);
+
+    this.currTileOverlayId++;
+
+    return { id: id };
+  }
+
+  async removeTileOverlay(_args: RemoveTileOverlayArgs): Promise<void> {
+    const map = this.maps[_args.id].map;
+    for (let i = 0; i < map.overlayMapTypes.getLength(); i++) {
+      if (map.overlayMapTypes.getAt(i) === this.maps[_args.id].tileOverlays[_args.tileOverlayId]) {
+        map.overlayMapTypes.removeAt(i);
+      }
+    }
+    delete this.maps[_args.id].tileOverlays[_args.tileOverlayId];
+  }
+
   async addMarkers(_args: AddMarkersArgs): Promise<{ ids: string[] }> {
     const markerIds: string[] = [];
     const map = this.maps[_args.id];
@@ -424,6 +472,7 @@ export class CapacitorGoogleMapsWeb extends WebPlugin implements CapacitorGoogle
       map: new window.google.maps.Map(_args.element, { ..._args.config }),
       element: _args.element,
       markers: {},
+      tileOverlays: {},
       polygons: {},
       circles: {},
       polylines: {},


### PR DESCRIPTION
These changes add methods to the map for adding/removing tile overlays.

Example:
```typescript
let map: GoogleMap;
// Create map

const id = await map.addTileOverlay({
  getTile: (x, y, zoom) => {
    return `https://a.basemaps.cartocdn.com/light_all/${zoom}/${x}/${y}.png`;
  },
  opacity: undefined, // number
  visible: undefined, // boolean
  zIndex: undefined, // number
});

await map.removeTileOverlay(id);
```

