### PR TITLE
chore: remove some GH token usage from CI

### DIFF
--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -9,17 +9,11 @@ on:
 jobs:
   setup:
     uses: ./.github/workflows/reusable_setup.yml
-    secrets:
-      CAP_GH_RELEASE_TOKEN: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
 
   lint-test:
     needs: 'setup'
     uses: ./.github/workflows/reusable_lint-packages.yml
-    secrets:
-      CAP_GH_RELEASE_TOKEN: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
 
   verify-packages:
     needs: 'setup'
     uses: ./.github/workflows/reusable_verify-packages.yml
-    secrets:
-      CAP_GH_RELEASE_TOKEN: ${{ secrets.CAP_GH_RELEASE_TOKEN }}

--- a/.github/workflows/reusable_lint-packages.yml
+++ b/.github/workflows/reusable_lint-packages.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     secrets:
       CAP_GH_RELEASE_TOKEN:
-        required: true
+        required: false
 
 jobs:
   lint:
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          token: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
+          token: ${{ secrets.CAP_GH_RELEASE_TOKEN || github.token }}
 
       - name: 'Setup Tools'
         uses: ./.github/actions/setup-tools

--- a/.github/workflows/reusable_setup.yml
+++ b/.github/workflows/reusable_setup.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     secrets:
       CAP_GH_RELEASE_TOKEN:
-        required: true
+        required: false
 
 jobs:
   setup:
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          token: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
+          token: ${{ secrets.CAP_GH_RELEASE_TOKEN || github.token  }}
 
       - name: 'Setup Tools'
         uses: ./.github/actions/setup-tools

--- a/.github/workflows/reusable_verify-packages.yml
+++ b/.github/workflows/reusable_verify-packages.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     secrets:
       CAP_GH_RELEASE_TOKEN:
-        required: true
+        required: false
 
 jobs:
 
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          token: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
+          token: ${{ secrets.CAP_GH_RELEASE_TOKEN || github.token }}
 
       - name: 'Setup Tools'
         uses: ./.github/actions/setup-tools
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          token: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
+          token: ${{ secrets.CAP_GH_RELEASE_TOKEN || github.token  }}
 
       - name: 'Setup Tools'
         uses: ./.github/actions/setup-tools
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          token: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
+          token: ${{ secrets.CAP_GH_RELEASE_TOKEN || github.token }}
 
       - name: 'Setup Tools'
         uses: ./.github/actions/setup-tools


### PR DESCRIPTION
This was causing CI to fail on any branch because of invalid Github Tokens, but technically basic_tests does not need to use the Github Token secret to run.