### PR TITLE
feat: add show/hide methods

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -381,6 +381,8 @@ Vue({
 * [`setOnMarkerDragEndListener(...)`](#setonmarkerdragendlistener)
 * [`setOnMyLocationButtonClickListener(...)`](#setonmylocationbuttonclicklistener)
 * [`setOnMyLocationClickListener(...)`](#setonmylocationclicklistener)
+* [`show()`](#show)
+* [`hide()`](#hide)
 * [Interfaces](#interfaces)
 * [Type Aliases](#type-aliases)
 * [Enums](#enums)
@@ -960,6 +962,24 @@ setOnMyLocationClickListener(callback?: MapListenerCallback<MapClickCallbackData
 | Param          | Type                                                                                                                                |
 | -------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
 | **`callback`** | <code><a href="#maplistenercallback">MapListenerCallback</a>&lt;<a href="#mapclickcallbackdata">MapClickCallbackData</a>&gt;</code> |
+
+--------------------
+
+
+### show()
+
+```typescript
+show() => Promise<void>
+```
+
+--------------------
+
+
+### hide()
+
+```typescript
+hide() => Promise<void>
+```
 
 --------------------
 

--- a/plugin/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMap.kt
+++ b/plugin/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMap.kt
@@ -769,6 +769,20 @@ class CapacitorGoogleMap(
         googleMap?.animateCamera(cameraUpdate)
     }
 
+    fun show() {
+        CoroutineScope(Dispatchers.Main).launch {
+            mapView.onResume()
+            mapView.visibility = View.VISIBLE
+        }
+    }
+
+    fun hide() {
+        CoroutineScope(Dispatchers.Main).launch {
+            mapView.onPause()
+            mapView.visibility = View.GONE
+        }
+    }
+
     private fun getScaledPixels(bridge: Bridge, pixels: Int): Int {
         // Get the screen's density scale
         val scale = bridge.activity.resources.displayMetrics.density

--- a/plugin/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMapsPlugin.kt
+++ b/plugin/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMapsPlugin.kt
@@ -1042,6 +1042,44 @@ class CapacitorGoogleMapsPlugin : Plugin(), OnMapsSdkInitializedCallback {
         }
     }
 
+    @PluginMethod
+    fun show(call: PluginCall) {
+        try {
+            val id = call.getString("id")
+            id ?: throw InvalidMapIdError()
+
+            val map = maps[id]
+            map ?: throw MapNotFoundError()
+
+            map.show()
+
+            call.resolve()
+        } catch (e: GoogleMapsError) {
+            handleError(call, e)
+        } catch (e: Exception) {
+            handleError(call, e)
+        }
+    }
+
+    @PluginMethod
+    fun hide(call: PluginCall) {
+        try {
+            val id = call.getString("id")
+            id ?: throw InvalidMapIdError()
+
+            val map = maps[id]
+            map ?: throw MapNotFoundError()
+
+            map.hide()
+
+            call.resolve()
+        } catch (e: GoogleMapsError) {
+            handleError(call, e)
+        } catch (e: Exception) {
+            handleError(call, e)
+        }
+    }
+
     private fun createLatLng(point: JSObject): LatLng {
         return LatLng(
             point.getDouble("lat"),

--- a/plugin/ios/Sources/CapacitorGoogleMapsPlugin/CapacitorGoogleMapsPlugin.swift
+++ b/plugin/ios/Sources/CapacitorGoogleMapsPlugin/CapacitorGoogleMapsPlugin.swift
@@ -100,7 +100,9 @@ public class CapacitorGoogleMapsPlugin: CAPPlugin, GMSMapViewDelegate, CAPBridge
         CAPPluginMethod(name: "getMapBounds", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "fitBounds", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "mapBoundsContains", returnType: CAPPluginReturnPromise),
-        CAPPluginMethod(name: "mapBoundsExtend", returnType: CAPPluginReturnPromise)
+        CAPPluginMethod(name: "mapBoundsExtend", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "show", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "hide", returnType: CAPPluginReturnPromise)
     ]
     private var maps = [String: Map]()
     private var isInitialized = false
@@ -968,6 +970,14 @@ public class CapacitorGoogleMapsPlugin: CAPPlugin, GMSMapViewDelegate, CAPBridge
         } catch {
             handleError(call, error: error)
         }
+    }
+
+    @objc func show(_ call: CAPPluginCall) {
+        call.resolve()
+    }
+
+    @objc func hide(_ call: CAPPluginCall) {
+        call.resolve()
     }
 
     private func getGMSCoordinateBounds(_ bounds: JSObject) throws -> GMSCoordinateBounds {

--- a/plugin/src/implementation.ts
+++ b/plugin/src/implementation.ts
@@ -215,6 +215,8 @@ export interface CapacitorGoogleMapsPlugin extends Plugin {
   fitBounds(args: FitBoundsArgs): Promise<void>;
   mapBoundsContains(args: MapBoundsContainsArgs): Promise<{ contains: boolean }>;
   mapBoundsExtend(args: MapBoundsExtendArgs): Promise<{ bounds: LatLngBounds }>;
+  show(args: { id: string }): Promise<void>;
+  hide(args: { id: string }): Promise<void>;
 }
 
 const CapacitorGoogleMaps = registerPlugin<CapacitorGoogleMapsPlugin>('CapacitorGoogleMaps', {

--- a/plugin/src/map.ts
+++ b/plugin/src/map.ts
@@ -88,6 +88,9 @@ export interface GoogleMapInterface {
   setOnMarkerDragEndListener(callback?: MapListenerCallback<MarkerClickCallbackData>): Promise<void>;
   setOnMyLocationButtonClickListener(callback?: MapListenerCallback<MyLocationButtonClickCallbackData>): Promise<void>;
   setOnMyLocationClickListener(callback?: MapListenerCallback<MapClickCallbackData>): Promise<void>;
+
+  show(): Promise<void>;
+  hide(): Promise<void>;
 }
 
 class MapCustomElement extends HTMLElement {
@@ -1105,5 +1108,17 @@ export class GoogleMap {
         callback(data);
       }
     };
+  }
+
+  async show(): Promise<void> {
+    return CapacitorGoogleMaps.show({
+      id: this.id,
+    });
+  }
+
+  async hide(): Promise<void> {
+    return CapacitorGoogleMaps.hide({
+      id: this.id,
+    });
   }
 }

--- a/plugin/src/web.ts
+++ b/plugin/src/web.ts
@@ -720,4 +720,12 @@ export class CapacitorGoogleMapsWeb extends WebPlugin implements CapacitorGoogle
 
     return advancedMarker;
   }
+
+  async show(): Promise<void> {
+    return;
+  }
+
+  async hide(): Promise<void> {
+    return;
+  }
 }


### PR DESCRIPTION
Hi there, I'v add two methods to control the native view's visibility on Android, it aims to solve the native map view overlapping issue in navigate between pages which all contain maps component.

With these two methods, in Ionic react page, we can hide the native map before leave, and show it before enter.

```React
useIonViewWillEnter(() => {
  map.current?.show().then(() => {
    console.log('map visible');
  });
});

useIonViewWillLeave(() => {
  setLocationId(undefined);
  map.current?.hide().then(() => {
    console.log('map invisible');
  });
});
```