### PR TITLE
fix(android): AGP 9.0 no longer supporting `proguard-android.txt`

### DIFF
--- a/plugin/android/build.gradle
+++ b/plugin/android/build.gradle
@@ -51,7 +51,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {


### PR DESCRIPTION
This change replaces the default proguard file `proguard-android.txt` with `proguard-android-optimize.txt` which allows proguard optimizations.

x-ref: https://github.com/ionic-team/capacitor/pull/8315 & https://github.com/ionic-team/capacitor-plugins/pull/2468