### PR TITLE
ci: update node to 24 and update action versions

### DIFF
--- a/.github/actions/setup-tools/action.yml
+++ b/.github/actions/setup-tools/action.yml
@@ -11,9 +11,9 @@ runs:
   using: "composite"
   steps:
     - name: Install Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v7
       with:
-        node-version: 22
+        node-version: 24
 
     - name: Install PNPM
       uses: pnpm/action-setup@v6

--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: 'macos-15'
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: 'Setup Tools'
@@ -39,7 +39,7 @@ jobs:
     runs-on: 'macos-15'
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: 'Setup Tools'
@@ -55,7 +55,7 @@ jobs:
     runs-on: 'macos-15'
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: 'Setup Tools'

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -13,7 +13,7 @@ jobs:
     name: ${{ github.event_name }}/${{ github.event.action }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
       - uses: ionic-team/bot@main
         with:
           repo-token: ${{ secrets.BOT_TOKEN }}

--- a/.github/workflows/dev-releases-for-pr.yml
+++ b/.github/workflows/dev-releases-for-pr.yml
@@ -19,7 +19,7 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
@@ -49,7 +49,7 @@ jobs:
         with:
           path: ./plugin
           
-      - uses: mshick/add-pr-comment@v2
+      - uses: mshick/add-pr-comment@v3
         with:
           message: |
             Released dev build of Google Maps with dev version: ${{ steps.package-version.outputs.current-version }}

--- a/.github/workflows/release-from-prerelease.yml
+++ b/.github/workflows/release-from-prerelease.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ secrets.CAP_GH_RELEASE_TOKEN }}

--- a/.github/workflows/reusable_lint-packages.yml
+++ b/.github/workflows/reusable_lint-packages.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: 'macos-15'
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ secrets.CAP_GH_RELEASE_TOKEN || github.token }}

--- a/.github/workflows/reusable_release-npm.yml
+++ b/.github/workflows/reusable_release-npm.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: 'ubuntu-24.04'
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ secrets.CAP_GH_RELEASE_TOKEN }}

--- a/.github/workflows/reusable_setup.yml
+++ b/.github/workflows/reusable_setup.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ secrets.CAP_GH_RELEASE_TOKEN || github.token  }}

--- a/.github/workflows/reusable_verify-packages.yml
+++ b/.github/workflows/reusable_verify-packages.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ secrets.CAP_GH_RELEASE_TOKEN || github.token }}
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ secrets.CAP_GH_RELEASE_TOKEN || github.token  }}
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ secrets.CAP_GH_RELEASE_TOKEN || github.token }}

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "typescript": "^5.9.3"
   },
   "engines": {
-    "node": ">=20",
-    "pnpm": ">=8"
+    "node": ">=24",
+    "pnpm": ">=9"
   },
   "workspaces": [
     "plugin"

--- a/publish-android.yml
+++ b/publish-android.yml
@@ -26,7 +26,7 @@ jobs:
       contents: read
       packages: write
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 0
         token: ${{ secrets.CAP_GH_RELEASE_TOKEN }}

--- a/publish-ios.yml
+++ b/publish-ios.yml
@@ -14,10 +14,10 @@ jobs:
       - run: sudo xcode-select --switch /Applications/Xcode_26_0.app
       - run: xcrun simctl list > /dev/null
       - run: xcodebuild -downloadPlatform iOS
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v7
         with:
-          node-version: 16
-      - uses: actions/checkout@v3
+          node-version: 24
+      - uses: actions/checkout@v7
       - name: Install Cocoapods
         run: | 
           gem install cocoapods


### PR DESCRIPTION
Equivalent PR to https://github.com/ionic-team/capacitor/pull/8557

Updates to macos runner and Xcode version are out-of-scope, to be done in other task / PR.

Internal JIRA Ref: https://outsystemsrd.atlassian.net/browse/RMET-4731