### PR TITLE
chore: update eslint to v10 and adopt @ionic/eslint-config

### DIFF
--- a/example-app-spm/package.json
+++ b/example-app-spm/package.json
@@ -50,12 +50,6 @@
     "eject": "react-scripts eject",
     "sync": "npm run build && npx cap sync"
   },
-  "eslintConfig": {
-    "extends": [
-      "react-app",
-      "react-app/jest"
-    ]
-  },
   "browserslist": {
     "production": [
       ">0.2%",

--- a/example-app/package.json
+++ b/example-app/package.json
@@ -50,12 +50,6 @@
     "eject": "react-scripts eject",
     "sync": "npm run build && npx cap sync"
   },
-  "eslintConfig": {
-    "extends": [
-      "react-app",
-      "react-app/jest"
-    ]
-  },
   "browserslist": {
     "production": [
       ">0.2%",

--- a/plugin/eslint.config.cjs
+++ b/plugin/eslint.config.cjs
@@ -1,51 +1,20 @@
-const eslintjs = require('@eslint/js');
-const tseslint = require('@typescript-eslint/eslint-plugin');
-const tseslintparser = require('@typescript-eslint/parser');
-const prettierConfig = require('eslint-config-prettier');
+const ionic = require('@ionic/eslint-config/recommended');
 
 module.exports = [
   {
-    ignores: ['node_modules/**', 'dist/**', 'build/**', '.build/**', 'unit-tests/**', 'android/**', 'ios/**', 'types/**', 'eslint.config.*'],
+    ignores: [
+      'node_modules/**',
+      'dist/**',
+      'build/**',
+      '.build/**',
+      'unit-tests/**',
+      'android/**',
+      'ios/**',
+      'types/**',
+      '**/*.js',
+      '**/*.mjs',
+      '**/*.cjs',
+    ],
   },
-  eslintjs.configs.recommended,
-  {
-    files: ['**/*.ts', '**/*.js'],
-    languageOptions: {
-      parser: tseslintparser,
-      ecmaVersion: 'latest',
-      sourceType: 'module',
-      globals: {
-        browser: 'readonly',
-        window: 'readonly',
-        document: 'readonly',
-        console: 'readonly',
-        HTMLElement: 'readonly',
-        customElements: 'readonly',
-        ResizeObserver: 'readonly',
-        DOMRect: 'readonly',
-        setTimeout: 'readonly',
-        setInterval: 'readonly',
-        clearInterval: 'readonly',
-        clearTimeout: 'readonly',
-        screen: 'readonly',
-        navigator: 'readonly',
-        GeolocationPosition: 'readonly',
-        google: 'readonly',
-      },
-    },
-    plugins: {
-      '@typescript-eslint': tseslint,
-    },
-    rules: {
-      ...tseslint.configs.recommended.rules,
-      '@typescript-eslint/no-explicit-any': 'off',
-      '@typescript-eslint/no-unused-expressions': 'off',
-      indent: ['error', 2],
-      'linebreak-style': ['error', 'unix'],
-      quotes: ['error', 'single'],
-      semi: ['error', 'always'],
-    },
-  },
-  prettierConfig,
+  ...ionic,
 ];
-

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -62,6 +62,7 @@
     "@capacitor/core": "next",
     "@capacitor/docgen": "0.3.0",
     "@capacitor/ios": "next",
+    "@ionic/eslint-config": "^0.5.0",
     "@ionic/prettier-config": "^4.0.0",
     "@types/resize-observer-browser": "^0.1.11",
     "@types/supercluster": "^7.1.3",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -67,7 +67,7 @@
     "@types/supercluster": "^7.1.3",
     "@typescript-eslint/eslint-plugin": "^8.48.0",
     "@typescript-eslint/parser": "^8.48.0",
-    "eslint": "^8.57.1",
+    "eslint": "^10.0.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-import": "^2.32.0",
     "prettier": "^3.6.2",

--- a/plugin/src/map.ts
+++ b/plugin/src/map.ts
@@ -609,8 +609,8 @@ export class GoogleMap {
   initScrolling(): void {
     const ionContents = document.getElementsByTagName('ion-content');
 
-    for (let i = 0; i < ionContents.length; i++) {
-      (ionContents[i] as any).scrollEvents = true;
+    for (const ionContent of Array.from(ionContents)) {
+      (ionContent as any).scrollEvents = true;
     }
 
     window.addEventListener('ionScroll', this.handleScrollEvent);
@@ -851,7 +851,7 @@ export class GoogleMap {
    * @returns
    */
   async setOnCircleClickListener(callback?: MapListenerCallback<CircleClickCallbackData>): Promise<void> {
-    if (this.onCircleClickListener) [this.onCircleClickListener.remove()];
+    if (this.onCircleClickListener) this.onCircleClickListener.remove();
 
     if (callback) {
       this.onCircleClickListener = await CapacitorGoogleMaps.addListener(

--- a/plugin/src/web.ts
+++ b/plugin/src/web.ts
@@ -687,7 +687,7 @@ export class CapacitorGoogleMapsWeb extends WebPlugin implements CapacitorGoogle
       throw new Error('Marker library not loaded');
     }
 
-    let content: HTMLElement | undefined = undefined;
+    let content: HTMLElement | undefined;
 
     if (marker.iconUrl) {
       const img = document.createElement('img');


### PR DESCRIPTION
## Description
Updates eslint to v10 and moves this repo onto `@ionic/eslint-config` 0.5.0.

The config here was hand-written and mostly a copy of the shared ionic rule set, so it's replaced with the shared config. The ignore list is kept as it was, plus `.js` files so we're linting the same thing as before. That drops most of the config file.

## Change Type
- [ ] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking Change
- [ ] Documentation
- [X] Other (CI, chores, etc.)

## Rationale / Problems Fixed
https://outsystemsrd.atlassian.net/browse/RMET-4734

Eslint 9 is end of life as of August 2026. Adopting the shared config while we're already in here means we don't change the lint setup twice back to back, and rule changes now come from one place instead of being copied into each repo.

## Platforms Affected
- [ ] Android
- [ ] iOS
- [X] Web

## Notes
Needs `@ionic/eslint-config@0.5.0` published first. Run `npm install` to update the lockfile.
